### PR TITLE
fix: voorkom false positives in monitoring voor NCSC.nl

### DIFF
--- a/scripts/monitor_content.py
+++ b/scripts/monitor_content.py
@@ -69,9 +69,11 @@ def normalize_html(html: str) -> str:
     html = re.sub(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[^\s\"'<]*", "", html)
     # Verwijder generator meta-tags
     html = re.sub(r'<meta\s+name="generator"[^>]*>', "", html)
-    # Verwijder nonces (HTML-attributen en JS-assignments)
+    # Verwijder nonces (HTML-attributen, JS-assignments en escaped JSON)
     html = re.sub(r'nonce="[^"]*"', "", html)
     html = re.sub(r'\.nonce\s*=\s*"[^"]*"', '.nonce = ""', html)
+    # Next.js/React escaped JSON nonces: \"nonce\":\"base64value\"
+    html = re.sub(r'\\"nonce\\":\\"[^"\\]*\\"', r'\\"nonce\\":\\"NONCE\\"', html)
     # Verwijder ReSpec-specifieke build timestamps
     html = re.sub(r"respecVersion\s*=\s*['\"][^'\"]*['\"]", "", html)
     # Verwijder HTML comments (build hashes, timestamps, etc.)
@@ -93,6 +95,8 @@ def normalize_html(html: str) -> str:
     html = re.sub(r"js-view-dom-id-[a-f0-9]+", "js-view-dom-id-HASH", html)
     # Drupal CMS: permissionsHash (verandert bij module/permissie updates)
     html = re.sub(r'"permissionsHash":"[a-f0-9]+"', '"permissionsHash":"HASH"', html)
+    # Next.js RSC streaming: inline data scripts veranderen chunking per request
+    html = re.sub(r"<script\s*>self\.__next_f\.push\([^<]*\)</script>", "", html)
     return html
 
 

--- a/skills/inet-web/reference.md
+++ b/skills/inet-web/reference.md
@@ -241,7 +241,7 @@ mv security.txt.signed .well-known/security.txt
 
 Bronnen:
 - [Forum Standaardisatie - security.txt](https://www.forumstandaardisatie.nl/open-standaarden/securitytxt)
-- [NCSC - Kwetsbaarheid melden (CVD)](https://www.ncsc.nl/contact/kwetsbaarheid-melden)
+- [NCSC - Kwetsbaarheid melden (CVD)](https://www.ncsc.nl/dienstverlening/kwetsbaarheid-melden-cvd)
 
 ## RPKI - details
 

--- a/skills/inet/SKILL.md
+++ b/skills/inet/SKILL.md
@@ -117,4 +117,4 @@ gh api repos/internetstandards/Internet.nl-API-docs/git/trees/main?recursive=1 \
 - [internet.nl/test-site](https://internet.nl/test-site/) - Website testen
 - [internet.nl/test-mail](https://internet.nl/test-mail/) - E-mail testen
 - [Forum Standaardisatie - Open standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
-- [NCSC - Publicaties](https://www.ncsc.nl/documenten)
+- [NCSC - Cybersecurity thema's](https://www.ncsc.nl/cybersecurity-themas)

--- a/tests/test_monitor_content.py
+++ b/tests/test_monitor_content.py
@@ -34,6 +34,24 @@ class TestNormalizeHtml:
         assert "xyz789" not in result
         assert '.nonce = ""' in result
 
+    def test_nonces_escaped_json(self):
+        """Next.js/React escaped JSON nonces (NCSC.nl pattern)."""
+        html = (
+            r":HL[\"/_next/static/css/file.css\","
+            r"\"style\",{\"nonce\":\"NGZjMWJjZmYtYTY4MS00YzIx\"}]"
+        )
+        result = normalize_html(html)
+        assert "NGZjMWJjZmYtYTY4MS00YzIx" not in result
+        assert r"\"nonce\":\"NONCE\"" in result
+
+    def test_nextjs_rsc_inline_scripts(self):
+        """Next.js RSC inline data scripts worden gestript (chunking varieert per request)."""
+        html = '<div>content</div><script >self.__next_f.push([1,"1e:data"])</script><p>more</p>'
+        result = normalize_html(html)
+        assert "self.__next_f" not in result
+        assert "<div>content</div>" in result
+        assert "<p>more</p>" in result
+
     def test_html_comments_verwijderd(self):
         html = "<div><!-- build hash: abc123 --><p>content</p></div>"
         result = normalize_html(html)

--- a/uv.lock
+++ b/uv.lock
@@ -97,7 +97,7 @@ wheels = [
 
 [[package]]
 name = "internet-nl-plugin"
-version = "0.1.0"
+version = "0.1.2"
 source = { virtual = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
## Summary

- NCSC.nl is een Next.js site die per request varierende nonces en RSC streaming chunks genereert, wat dagelijks false positive monitoring issues veroorzaakte
- `normalize_html` uitgebreid met twee nieuwe patronen: escaped JSON nonces (`\"nonce\":\"...\"`) en Next.js RSC inline data scripts (`self.__next_f.push(...)`)
- Verouderde NCSC URLs bijgewerkt die nu redirecten (`/documenten` → `/cybersecurity-themas`, `/contact/kwetsbaarheid-melden` → `/dienstverlening/kwetsbaarheid-melden-cvd`)

Fixes #6, fixes #7, fixes #8

## Test plan

- [x] Alle 58 tests slagen
- [x] Ruff lint + format schoon
- [x] Live verificatie: alle drie NCSC URLs produceren stabiele hashes na normalisatie