### PR TITLE
fix: corrigeer feitelijke fouten in skills (MTA-STS, RPKI, IPv6)

### DIFF
--- a/skills/inet-api/reference.md
+++ b/skills/inet-api/reference.md
@@ -182,6 +182,12 @@ Bron: [Terms of Use](https://github.com/internetstandards/Internet.nl-API-docs/b
                 "web_appsecpriv_x_frame": {"verdict": "passed"},
                 "web_appsecpriv_securitytxt": {"verdict": "passed"}
               }
+            },
+            "rpki": {
+              "verdict": "passed",
+              "tests": {
+                "web_rpki_exists": {"verdict": "passed"}
+              }
             }
           }
         },
@@ -238,6 +244,11 @@ De mailtest bevat andere categorieen:
         "mail_tls_dane_exist": {},
         "mail_tls_dane_valid": {},
         "mail_tls_dane_rollover": {}
+      }
+    },
+    "rpki": {
+      "tests": {
+        "mail_rpki_exists": {}
       }
     }
   }

--- a/skills/inet-mail/SKILL.md
+++ b/skills/inet-mail/SKILL.md
@@ -3,7 +3,7 @@ name: inet-mail
 description: >-
   Mailstandaarden getest door internet.nl: SPF (Sender Policy Framework),
   DKIM (DomainKeys Identified Mail), DMARC (Domain-based Message Authentication),
-  STARTTLS, MTA-STS, DANE (DNS-based Authentication of Named Entities).
+  STARTTLS, DANE (DNS-based Authentication of Named Entities).
   Triggers: mail test, DMARC, DKIM, SPF, STARTTLS, DANE,
   mailserver beveiliging, email security, e-mailbeveiliging,
   mailstandaarden, anti-spoofing
@@ -194,17 +194,15 @@ _dmarc.example.nl. IN TXT "v=DMARC1; p=reject; rua=mailto:dmarc@example.nl; adki
 dig TXT _dmarc.example.nl +short
 ```
 
-### 4. STARTTLS en MTA-STS
+### 4. STARTTLS
 
-**Wat:** STARTTLS versleutelt SMTP-verkeer tussen mailservers. MTA-STS
-(Mail Transfer Agent Strict Transport Security) dwingt af dat TLS wordt gebruikt.
+**Wat:** STARTTLS versleutelt SMTP-verkeer tussen mailservers.
 
 **Wat test internet.nl:**
 - MX-servers ondersteunen STARTTLS
 - TLS 1.2 of hoger (TLS 1.0/1.1 geeft een phase-out waarschuwing; SSL 2.0/3.0 is een harde fout)
 - Geldig certificaat
 - Geen terugval naar onversleuteld verkeer
-- MTA-STS beleid (optioneel maar aanbevolen)
 
 **Testen:**
 
@@ -215,25 +213,6 @@ dig MX example.nl +short
 # STARTTLS testen op MX-server
 openssl s_client -connect mx.example.nl:25 -starttls smtp </dev/null 2>/dev/null | \
   grep -E '(Protocol|Cipher|Verify)'
-
-# MTA-STS beleid ophalen
-curl -s https://mta-sts.example.nl/.well-known/mta-sts.txt
-```
-
-**MTA-STS DNS-record:**
-
-```dns
-_mta-sts.example.nl. IN TXT "v=STSv1; id=20260101T000000"
-```
-
-**MTA-STS beleidsbestand** (op `https://mta-sts.example.nl/.well-known/mta-sts.txt`):
-
-```text
-version: STSv1
-mode: enforce
-mx: mx1.example.nl
-mx: mx2.example.nl
-max_age: 604800
 ```
 
 ### 5. DANE (DNS-based Authentication of Named Entities)
@@ -299,7 +278,6 @@ dig MX example.nl +dnssec +short
 | DMARC `p=none` is onvoldoende | Fase 1 monitoring nog actief | Verschuif naar `p=quarantine` of `p=reject` |
 | STARTTLS niet aangeboden | Mailserver niet geconfigureerd | Schakel TLS in op de mailserver |
 | DANE TLSA mismatch | Certificaat vernieuwd zonder TLSA-update | Werk TLSA-record bij met hash van nieuw certificaat |
-| MTA-STS validatie faalt | Certificaat of DNS niet correct | Controleer dat `mta-sts.example.nl` een geldig certificaat heeft |
 
 ## Achtergrondinfo
 

--- a/skills/inet-mail/reference.md
+++ b/skills/inet-mail/reference.md
@@ -259,6 +259,9 @@ echo "Nieuw TLSA-record: _25._tcp.$DOMAIN. IN TLSA 3 1 1 $HASH"
 
 ## MTA-STS configuratie
 
+> **Let op:** MTA-STS wordt niet getest door internet.nl. Het is een aanvullende
+> best practice naast DANE.
+
 ### Vereisten
 
 1. DNS TXT-record: `_mta-sts.example.nl`
@@ -300,7 +303,6 @@ Verzendende server                    Ontvangende server
      |-- SPF (IP check via DNS) -->         |
      |-- STARTTLS (versleuteling) -------->  |
      |      \-- DANE (cert verificatie) --> |
-     |      \-- MTA-STS (TLS afdwingen) -> |
      |                                      |
      |                              DMARC beleid toepassen
      |                              (op basis van SPF+DKIM)

--- a/skills/inet/SKILL.md
+++ b/skills/inet/SKILL.md
@@ -29,7 +29,7 @@ De standaarden staan op de
 | Skill | Wanneer gebruiken | Standaarden |
 |-------|-------------------|-------------|
 | `/inet-web` | Website testen, HTTPS/TLS instellen, security headers | IPv6, DNSSEC, HTTPS/TLS, HSTS, security headers, security.txt, RPKI |
-| `/inet-mail` | E-mail beveiligen, DNS records voor mail | SPF, DKIM, DMARC, STARTTLS, DANE, MTA-STS |
+| `/inet-mail` | E-mail beveiligen, DNS records voor mail | SPF, DKIM, DMARC, STARTTLS, DANE, IPv6, RPKI |
 | `/inet-api` | Bulk scans via de API, dashboards bouwen | Batch API v2, authenticatie, resultaten JSON |
 | `/inet-toolbox` | Stap-voor-stap implementatie, server configuratie | DNSSEC, HTTPS, DMARC, DKIM, SPF, DANE, IPv6 |
 
@@ -63,7 +63,8 @@ De standaarden staan op de
 | DKIM | Verplicht (pas-toe-of-leg-uit) | DomainKeys Identified Mail, digitale handtekening op e-mail |
 | DMARC | Verplicht (pas-toe-of-leg-uit) | Domain-based Message Authentication, bouwt voort op SPF+DKIM |
 | STARTTLS + DANE | Verplicht (pas-toe-of-leg-uit) | Versleuteling van SMTP-verkeer + DNS-gebaseerde certificaatverificatie |
-| MTA-STS | Getest door internet.nl (geen Forum status) | Mail Transfer Agent Strict Transport Security, dwingt TLS af |
+| IPv6 | Verplicht (pas-toe-of-leg-uit) | Internetprotocol versie 6, bereikbaarheid van MX- en nameservers |
+| RPKI | Verplicht (pas-toe-of-leg-uit) | Route Origin Validation voor MX- en nameservers |
 
 ## Repositories
 


### PR DESCRIPTION
## Summary

- MTA-STS verwijderd als "getest door internet.nl" — broncode bevestigt dat dit niet het geval is
- IPv6 en RPKI toegevoegd aan mailstandaarden overzicht (worden wél getest door internet.nl)
- RPKI categorie toegevoegd aan API response voorbeelden voor zowel web als mail
- MTA-STS configuratie behouden in reference.md als aanvullende best practice, met duidelijke disclaimer
- MTA-STS verwijderd uit relatiediagram in reference.md

## Gewijzigde bestanden

- `skills/inet/SKILL.md` — sub-skills tabel en mailstandaarden tabel
- `skills/inet-mail/SKILL.md` — description, sectie 4, troubleshooting
- `skills/inet-mail/reference.md` — disclaimer + relatiediagram
- `skills/inet-api/reference.md` — RPKI in web- en mailtest response voorbeelden

## Test plan

- [x] `grep -ri "mta-sts" skills/` — alleen in reference.md met disclaimer
- [x] `grep -ri "rpki" skills/` — vermeld bij zowel web als mail
- [x] `uv run ruff check` — passed
- [x] `uv run pytest -v` — 58 tests passed
- [x] Pre-commit hooks (markdownlint, ruff, yaml, json) — all passed

Closes #11