### PR TITLE
Update repo references for org/repo rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,24 @@
 # Changelog
 
-## [0.1.3](https://github.com/MinBZK/internet-nl-plugin/compare/v0.1.2...v0.1.3) (2026-02-23)
+## [0.1.3](https://github.com/developer-overheid-nl/internet-plugin/compare/v0.1.2...v0.1.3) (2026-02-23)
 
 
 ### Opgelost
 
-* voorkom false positives in monitoring voor NCSC.nl (Next.js) ([#9](https://github.com/MinBZK/internet-nl-plugin/issues/9)) ([44351e3](https://github.com/MinBZK/internet-nl-plugin/commit/44351e39a8588f2de6fe3bb67fa6b19d44266db2))
+* voorkom false positives in monitoring voor NCSC.nl (Next.js) ([#9](https://github.com/developer-overheid-nl/internet-plugin/issues/9)) ([44351e3](https://github.com/developer-overheid-nl/internet-plugin/commit/44351e39a8588f2de6fe3bb67fa6b19d44266db2))
 
-## [0.1.2](https://github.com/MinBZK/internet-nl-plugin/compare/v0.1.1...v0.1.2) (2026-02-22)
-
-
-### Opgelost
-
-* handle all URL types in content monitor ([#4](https://github.com/MinBZK/internet-nl-plugin/issues/4)) ([5cb6a2b](https://github.com/MinBZK/internet-nl-plugin/commit/5cb6a2b3bf1d9a29a0cfbb0a98c4b9bb001b9eff))
-
-## [0.1.1](https://github.com/MinBZK/internet-nl-plugin/compare/v0.1.0...v0.1.1) (2026-02-22)
+## [0.1.2](https://github.com/developer-overheid-nl/internet-plugin/compare/v0.1.1...v0.1.2) (2026-02-22)
 
 
 ### Opgelost
 
-* corrigeer API endpoints, rate limits en dode NCSC URLs ([add7455](https://github.com/MinBZK/internet-nl-plugin/commit/add7455eeb3cf713a61c36f00805184a1206faa0))
+* handle all URL types in content monitor ([#4](https://github.com/developer-overheid-nl/internet-plugin/issues/4)) ([5cb6a2b](https://github.com/developer-overheid-nl/internet-plugin/commit/5cb6a2b3bf1d9a29a0cfbb0a98c4b9bb001b9eff))
+
+## [0.1.1](https://github.com/developer-overheid-nl/internet-plugin/compare/v0.1.0...v0.1.1) (2026-02-22)
+
+
+### Opgelost
+
+* corrigeer API endpoints, rate limits en dode NCSC URLs ([add7455](https://github.com/developer-overheid-nl/internet-plugin/commit/add7455eeb3cf713a61c36f00805184a1206faa0))
 
 ## Changelog

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@
 
 ```bash
 # Via de overheid-plugins marketplace (aanbevolen)
-claude plugin marketplace add MinBZK/overheid-claude-plugins
+claude plugin marketplace add developer-overheid-nl/overheid-claude-plugins
 claude plugin install internet-nl@overheid-plugins
 
 # Per sessie
-git clone https://github.com/MinBZK/internet-nl-plugin.git
-claude --plugin-dir ./internet-nl-plugin
+git clone https://github.com/developer-overheid-nl/internet-plugin.git
+claude --plugin-dir ./internet-plugin
 ```
 
 ## Skills
@@ -45,7 +45,7 @@ De skills zijn gebaseerd op:
 
 ## Onderdeel van
 
-Deze plugin is onderdeel van de [overheid-claude-plugins](https://github.com/MinBZK/overheid-claude-plugins) marketplace.
+Deze plugin is onderdeel van de [overheid-claude-plugins](https://github.com/developer-overheid-nl/overheid-claude-plugins) marketplace.
 
 ## Licentie
 

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -40,10 +40,10 @@ localisation:
   localisationReady: false
 maintenance:
   contacts:
-    - name: MinBZK
+    - name: developer-overheid-nl
   type: community
-name: internet-nl-plugin
+name: internet-plugin
 releaseDate: '2026-02-22'
 softwareVersion: 0.1.3
 softwareType: standalone/other
-url: https://github.com/MinBZK/internet-nl-plugin
+url: https://github.com/developer-overheid-nl/internet-plugin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "internet-nl-plugin"
+name = "internet-plugin"
 version = "0.1.3"
 description = "Internet.nl Claude Code Plugin - Test en implementeer moderne internetstandaarden"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -96,7 +96,7 @@ wheels = [
 ]
 
 [[package]]
-name = "internet-nl-plugin"
+name = "internet-plugin"
 version = "0.1.2"
 source = { virtual = "." }
 dependencies = [


### PR DESCRIPTION
## Summary
- Updated all references from `MinBZK/internet-nl-plugin` to `developer-overheid-nl/internet-plugin` across README.md, CHANGELOG.md, publiccode.yml, pyproject.toml, and uv.lock
- Updated git remote origin URL to point to the new repository location
- Updated marketplace references from `MinBZK/overheid-claude-plugins` to `developer-overheid-nl/overheid-claude-plugins`

## Test plan
- [ ] Verify all links in README.md resolve correctly
- [ ] Verify all links in CHANGELOG.md resolve correctly
- [ ] Verify `publiccode.yml` passes validation
- [ ] Verify `uv lock` still works with the renamed package