### PR TITLE
Fix Liferay timestamp regex voor &t= in query strings

### DIFF
--- a/scripts/monitor_content.py
+++ b/scripts/monitor_content.py
@@ -104,8 +104,8 @@ def normalize_html(html: str) -> str:
     # Liferay CMS: authToken / p_auth CSRF token (verandert per request)
     html = re.sub(r"Liferay\.authToken\s*=\s*'[^']*'", "Liferay.authToken = 'TOKEN'", html)
     html = re.sub(r'name="p_auth"\s+value="[^"]*"', 'name="p_auth" value="TOKEN"', html)
-    # Liferay CMS: cache-bust timestamp op resource URLs (bijv. ?t=1771832749422)
-    html = re.sub(r"\?t=\d{10,15}", "?t=TIMESTAMP", html)
+    # Liferay CMS: cache-bust timestamp op resource URLs (bijv. ?t=1771832749422 of &t=...)
+    html = re.sub(r"[?&]t=\d{10,15}", "?t=TIMESTAMP", html)
     return html
 
 


### PR DESCRIPTION
## Summary

- Fix `normalize_html` regex om ook `&t=` timestamps midden in Liferay combo query strings te matchen (naast `?t=` aan het begin)

## Test plan

- [ ] Verify geen Liferay-gerelateerde false positives meer