### PR TITLE
chore: update repo references after rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,31 +1,31 @@
 # Changelog
 
-## [0.1.4](https://github.com/developer-overheid-nl/internet-plugin/compare/v0.1.3...v0.1.4) (2026-02-26)
+## [0.1.4](https://github.com/developer-overheid-nl/skills-internet/compare/v0.1.3...v0.1.4) (2026-02-26)
 
 
 ### Opgelost
 
-* corrigeer feitelijke fouten in skills (MTA-STS, RPKI, IPv6) ([#12](https://github.com/developer-overheid-nl/internet-plugin/issues/12)) ([f84b55b](https://github.com/developer-overheid-nl/internet-plugin/commit/f84b55b5b8f9c480bbc2591fa96f2e0208edb424)), closes [#11](https://github.com/developer-overheid-nl/internet-plugin/issues/11)
+* corrigeer feitelijke fouten in skills (MTA-STS, RPKI, IPv6) ([#12](https://github.com/developer-overheid-nl/skills-internet/issues/12)) ([f84b55b](https://github.com/developer-overheid-nl/skills-internet/commit/f84b55b5b8f9c480bbc2591fa96f2e0208edb424)), closes [#11](https://github.com/developer-overheid-nl/skills-internet/issues/11)
 
-## [0.1.3](https://github.com/developer-overheid-nl/internet-plugin/compare/v0.1.2...v0.1.3) (2026-02-23)
-
-
-### Opgelost
-
-* voorkom false positives in monitoring voor NCSC.nl (Next.js) ([#9](https://github.com/developer-overheid-nl/internet-plugin/issues/9)) ([44351e3](https://github.com/developer-overheid-nl/internet-plugin/commit/44351e39a8588f2de6fe3bb67fa6b19d44266db2))
-
-## [0.1.2](https://github.com/developer-overheid-nl/internet-plugin/compare/v0.1.1...v0.1.2) (2026-02-22)
+## [0.1.3](https://github.com/developer-overheid-nl/skills-internet/compare/v0.1.2...v0.1.3) (2026-02-23)
 
 
 ### Opgelost
 
-* handle all URL types in content monitor ([#4](https://github.com/developer-overheid-nl/internet-plugin/issues/4)) ([5cb6a2b](https://github.com/developer-overheid-nl/internet-plugin/commit/5cb6a2b3bf1d9a29a0cfbb0a98c4b9bb001b9eff))
+* voorkom false positives in monitoring voor NCSC.nl (Next.js) ([#9](https://github.com/developer-overheid-nl/skills-internet/issues/9)) ([44351e3](https://github.com/developer-overheid-nl/skills-internet/commit/44351e39a8588f2de6fe3bb67fa6b19d44266db2))
 
-## [0.1.1](https://github.com/developer-overheid-nl/internet-plugin/compare/v0.1.0...v0.1.1) (2026-02-22)
+## [0.1.2](https://github.com/developer-overheid-nl/skills-internet/compare/v0.1.1...v0.1.2) (2026-02-22)
 
 
 ### Opgelost
 
-* corrigeer API endpoints, rate limits en dode NCSC URLs ([add7455](https://github.com/developer-overheid-nl/internet-plugin/commit/add7455eeb3cf713a61c36f00805184a1206faa0))
+* handle all URL types in content monitor ([#4](https://github.com/developer-overheid-nl/skills-internet/issues/4)) ([5cb6a2b](https://github.com/developer-overheid-nl/skills-internet/commit/5cb6a2b3bf1d9a29a0cfbb0a98c4b9bb001b9eff))
+
+## [0.1.1](https://github.com/developer-overheid-nl/skills-internet/compare/v0.1.0...v0.1.1) (2026-02-22)
+
+
+### Opgelost
+
+* corrigeer API endpoints, rate limits en dode NCSC URLs ([add7455](https://github.com/developer-overheid-nl/skills-internet/commit/add7455eeb3cf713a61c36f00805184a1206faa0))
 
 ## Changelog

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@
 
 ```bash
 # Via de overheid-plugins marketplace (aanbevolen)
-claude plugin marketplace add developer-overheid-nl/overheid-claude-plugins
+claude plugin marketplace add developer-overheid-nl/skills-marketplace
 claude plugin install internet-nl@overheid-plugins
 
 # Per sessie
-git clone https://github.com/developer-overheid-nl/internet-plugin.git
-claude --plugin-dir ./internet-plugin
+git clone https://github.com/developer-overheid-nl/skills-internet.git
+claude --plugin-dir ./skills-internet
 ```
 
 ## Skills
@@ -45,7 +45,7 @@ De skills zijn gebaseerd op:
 
 ## Onderdeel van
 
-Deze plugin is onderdeel van de [overheid-claude-plugins](https://github.com/developer-overheid-nl/overheid-claude-plugins) marketplace.
+Deze plugin is onderdeel van de [skills-marketplace](https://github.com/developer-overheid-nl/skills-marketplace) marketplace.
 
 ## Disclaimer
 

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -42,8 +42,8 @@ maintenance:
   contacts:
     - name: developer-overheid-nl
   type: community
-name: internet-plugin
+name: skills-internet
 releaseDate: '2026-02-22'
 softwareVersion: 0.1.4
 softwareType: standalone/other
-url: https://github.com/developer-overheid-nl/internet-plugin
+url: https://github.com/developer-overheid-nl/skills-internet

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "internet-plugin"
+name = "skills-internet"
 version = "0.1.4"
 description = "Internet.nl Claude Code Plugin - Test en implementeer moderne internetstandaarden"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -97,7 +97,7 @@ wheels = [
 
 [[package]]
 name = "internet-plugin"
-version = "0.1.2"
+version = "0.1.4"
 source = { virtual = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
## Samenvatting

Update alle interne referenties na repo rename:
- `internet-plugin` → `skills-internet`
- `overheid-claude-plugins` → `skills-marketplace`