### PR TITLE
Add metadata to all SKILL.md files

### DIFF
--- a/skills/inet-api/SKILL.md
+++ b/skills/inet-api/SKILL.md
@@ -12,6 +12,11 @@ allowed-tools:
   - Bash(gh api *)
   - Bash(curl -s *)
   - WebFetch(*)
+metadata:
+  created-with-ai: "true"
+  created-with-model: claude-opus-4-20250514
+  created-date: "2025-02-22"
+  status: concept
 ---
 
 > **Let op:** Deze skill is geen officieel product van internet.nl. De beschrijvingen zijn informatieve samenvattingen — niet de officiële standaarden zelf. De testcriteria op [internet.nl](https://internet.nl) en de definities op [forumstandaardisatie.nl](https://www.forumstandaardisatie.nl/open-standaarden) zijn altijd leidend. Overheidsorganisaties die generatieve AI inzetten dienen te voldoen aan het [Rijksbrede beleidskader voor generatieve AI](https://www.government.nl/documents/policy-notes/2025/01/31/government-wide-position-on-the-use-of-generative-ai). Zie [DISCLAIMER.md](../../DISCLAIMER.md).

--- a/skills/inet-mail/SKILL.md
+++ b/skills/inet-mail/SKILL.md
@@ -14,6 +14,11 @@ allowed-tools:
   - Bash(dig *)
   - Bash(openssl *)
   - WebFetch(*)
+metadata:
+  created-with-ai: "true"
+  created-with-model: claude-opus-4-20250514
+  created-date: "2025-02-22"
+  status: concept
 ---
 
 > **Let op:** Deze skill is geen officieel product van internet.nl. De beschrijvingen zijn informatieve samenvattingen — niet de officiële standaarden zelf. De testcriteria op [internet.nl](https://internet.nl) en de definities op [forumstandaardisatie.nl](https://www.forumstandaardisatie.nl/open-standaarden) zijn altijd leidend. Overheidsorganisaties die generatieve AI inzetten dienen te voldoen aan het [Rijksbrede beleidskader voor generatieve AI](https://www.government.nl/documents/policy-notes/2025/01/31/government-wide-position-on-the-use-of-generative-ai). Zie [DISCLAIMER.md](../../DISCLAIMER.md).

--- a/skills/inet-toolbox/SKILL.md
+++ b/skills/inet-toolbox/SKILL.md
@@ -14,6 +14,11 @@ allowed-tools:
   - Bash(dig *)
   - Bash(openssl *)
   - WebFetch(*)
+metadata:
+  created-with-ai: "true"
+  created-with-model: claude-opus-4-20250514
+  created-date: "2025-02-22"
+  status: concept
 ---
 
 > **Let op:** Deze skill is geen officieel product van internet.nl. De beschrijvingen zijn informatieve samenvattingen — niet de officiële standaarden zelf. De testcriteria op [internet.nl](https://internet.nl) en de definities op [forumstandaardisatie.nl](https://www.forumstandaardisatie.nl/open-standaarden) zijn altijd leidend. Overheidsorganisaties die generatieve AI inzetten dienen te voldoen aan het [Rijksbrede beleidskader voor generatieve AI](https://www.government.nl/documents/policy-notes/2025/01/31/government-wide-position-on-the-use-of-generative-ai). Zie [DISCLAIMER.md](../../DISCLAIMER.md).

--- a/skills/inet-web/SKILL.md
+++ b/skills/inet-web/SKILL.md
@@ -15,6 +15,11 @@ allowed-tools:
   - Bash(dig *)
   - Bash(openssl *)
   - WebFetch(*)
+metadata:
+  created-with-ai: "true"
+  created-with-model: claude-opus-4-20250514
+  created-date: "2025-02-22"
+  status: concept
 ---
 
 > **Let op:** Deze skill is geen officieel product van internet.nl. De beschrijvingen zijn informatieve samenvattingen — niet de officiële standaarden zelf. De testcriteria op [internet.nl](https://internet.nl) en de definities op [forumstandaardisatie.nl](https://www.forumstandaardisatie.nl/open-standaarden) zijn altijd leidend. Overheidsorganisaties die generatieve AI inzetten dienen te voldoen aan het [Rijksbrede beleidskader voor generatieve AI](https://www.government.nl/documents/policy-notes/2025/01/31/government-wide-position-on-the-use-of-generative-ai). Zie [DISCLAIMER.md](../../DISCLAIMER.md).

--- a/skills/inet/SKILL.md
+++ b/skills/inet/SKILL.md
@@ -11,6 +11,11 @@ allowed-tools:
   - Bash(gh api *)
   - Bash(curl -s *)
   - WebFetch(*)
+metadata:
+  created-with-ai: "true"
+  created-with-model: claude-opus-4-20250514
+  created-date: "2025-02-22"
+  status: concept
 ---
 
 > **Let op:** Deze skill is geen officieel product van internet.nl. De beschrijvingen zijn informatieve samenvattingen — niet de officiële standaarden zelf. De testcriteria op [internet.nl](https://internet.nl) en de definities op [forumstandaardisatie.nl](https://www.forumstandaardisatie.nl/open-standaarden) zijn altijd leidend. Overheidsorganisaties die generatieve AI inzetten dienen te voldoen aan het [Rijksbrede beleidskader voor generatieve AI](https://www.government.nl/documents/policy-notes/2025/01/31/government-wide-position-on-the-use-of-generative-ai). Zie [DISCLAIMER.md](../../DISCLAIMER.md).


### PR DESCRIPTION
## Summary
- Adds metadata block to all 5 SKILL.md frontmatter sections
- Fields: created-with-ai, created-with-model, created-date, status
- Required for skills-experiment verantwoordingsdocument

## Test plan
- [x] YAML frontmatter validates correctly
- [ ] Skills still load correctly in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)