### PR TITLE
Voeg licentiekolom toe aan Repositories-tabellen

### DIFF
--- a/skills/inet-api/SKILL.md
+++ b/skills/inet-api/SKILL.md
@@ -385,7 +385,7 @@ regelmatig te scannen en trends bij te houden.
 
 | Repository | Beschrijving | Licentie |
 |-----------|-------------|--------|
-| [Internet.nl-API-docs](https://github.com/internetstandards/Internet.nl-API-docs) | Officieel API-documentatie | Niet gespecificeerd |
+| [Internet.nl-API-docs](https://github.com/internetstandards/Internet.nl-API-docs) | Officieel API-documentatie | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) |
 | [Internet.nl](https://github.com/internetstandards/Internet.nl) | Testsuite broncode | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) |
 
 ## Veelvoorkomende problemen

--- a/skills/inet-mail/SKILL.md
+++ b/skills/inet-mail/SKILL.md
@@ -274,7 +274,7 @@ dig MX example.nl +dnssec +short
 | Repository | Beschrijving | Licentie |
 |-----------|-------------|--------|
 | [Internet.nl](https://github.com/internetstandards/Internet.nl) | Testsuite broncode | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) |
-| [toolbox-wiki](https://github.com/internetstandards/toolbox-wiki) | Implementatiegidsen | Niet gespecificeerd |
+| [toolbox-wiki](https://github.com/internetstandards/toolbox-wiki) | Implementatiegidsen | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) |
 
 ## Veelvoorkomende problemen
 

--- a/skills/inet-toolbox/SKILL.md
+++ b/skills/inet-toolbox/SKILL.md
@@ -388,7 +388,7 @@ ping6 example.nl
 
 | Repository | Beschrijving | Licentie |
 |-----------|-------------|--------|
-| [toolbox-wiki](https://github.com/internetstandards/toolbox-wiki) | Implementatiegidsen (bronmateriaal) | Niet gespecificeerd |
+| [toolbox-wiki](https://github.com/internetstandards/toolbox-wiki) | Implementatiegidsen (bronmateriaal) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) |
 | [Internet.nl](https://github.com/internetstandards/Internet.nl) | Testsuite om resultaat te controleren | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) |
 
 ## Veelvoorkomende problemen

--- a/skills/inet-web/SKILL.md
+++ b/skills/inet-web/SKILL.md
@@ -299,7 +299,7 @@ curl -s "https://stat.ripe.net/data/rpki-validation/data.json?resource=${ip}" | 
 | Repository | Beschrijving | Licentie |
 |-----------|-------------|--------|
 | [Internet.nl](https://github.com/internetstandards/Internet.nl) | Testsuite broncode (Python/Django) | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) |
-| [toolbox-wiki](https://github.com/internetstandards/toolbox-wiki) | Implementatiegidsen per standaard | Niet gespecificeerd |
+| [toolbox-wiki](https://github.com/internetstandards/toolbox-wiki) | Implementatiegidsen per standaard | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) |
 
 ## Veelvoorkomende problemen
 

--- a/skills/inet/SKILL.md
+++ b/skills/inet/SKILL.md
@@ -81,8 +81,8 @@ De broncode en documentatie staan onder de GitHub-organisatie
 | Repository | Beschrijving | Licentie |
 |-----------|-------------|--------|
 | [Internet.nl](https://github.com/internetstandards/Internet.nl) | De internet.nl testsuite (Python/Django) | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) |
-| [Internet.nl-API-docs](https://github.com/internetstandards/Internet.nl-API-docs) | Documentatie voor de batch API (v2) | Niet gespecificeerd |
-| [toolbox-wiki](https://github.com/internetstandards/toolbox-wiki) | Implementatiegidsen per standaard en platform | Niet gespecificeerd |
+| [Internet.nl-API-docs](https://github.com/internetstandards/Internet.nl-API-docs) | Documentatie voor de batch API (v2) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) |
+| [toolbox-wiki](https://github.com/internetstandards/toolbox-wiki) | Implementatiegidsen per standaard en platform | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) |
 
 ## Handige commando's voor repo-exploratie
 

--- a/skills/inet/conflicts.md
+++ b/skills/inet/conflicts.md
@@ -4,14 +4,14 @@ Geconstateerd: 2026-03-05
 
 ## Licentie-status GitHub-repositories
 
-De internet.nl testsuite heeft een dual-license: Apache-2.0 voor de broncode en CC-BY-4.0 voor vertalingen (zie `LICENSE.spdx` in de repository). De overige repositories in de [internetstandards](https://github.com/internetstandards) organisatie bevatten geen expliciet `LICENSE`-bestand.
+Alle repositories in de [internetstandards](https://github.com/internetstandards) organisatie bevatten een licentiebestand.
 
 | Repository | GitHub LICENSE | Status |
 |-----------|--------------|--------|
 | [Internet.nl](https://github.com/internetstandards/Internet.nl) | Apache-2.0 (code) + CC-BY-4.0 (vertalingen) | OK |
-| [Internet.nl-API-docs](https://github.com/internetstandards/Internet.nl-API-docs) | Geen | Geen licentie |
-| [toolbox-wiki](https://github.com/internetstandards/toolbox-wiki) | Geen | Geen licentie |
+| [Internet.nl-API-docs](https://github.com/internetstandards/Internet.nl-API-docs) | CC-BY-4.0 | OK |
+| [toolbox-wiki](https://github.com/internetstandards/toolbox-wiki) | CC-BY-4.0 | OK |
 
-### Aandachtspunt
+### Opmerking
 
-Het verdient aanbeveling dat de repositories `Internet.nl-API-docs` en `toolbox-wiki` expliciet een `LICENSE`-bestand toevoegen om juridische duidelijkheid te bieden, relevant voor artikel 15n Auteurswet (text and data mining exceptie).
+De GitHub API detecteert de licentie van Internet.nl niet (toont `none`) omdat de repo meerdere licentiebestanden gebruikt (`LICENSE-Apache-2.0.txt`, `LICENSE-CC-BY-4.0.txt`, `LICENSE.spdx`). De SPDX-file specificeert Apache-2.0 als hoofdlicentie voor de code en CC-BY-4.0 voor vertalingen.


### PR DESCRIPTION
## Summary

- Voegt een **Licentie** kolom toe aan alle Repositories-tabellen in de 5 SKILL.md bestanden
- Internet.nl = Apache-2.0, API-docs en toolbox-wiki = CC-BY-4.0
- Voegt `conflicts.md` toe voor het documenteren van licentie-status per repository

## Motivatie

Transparantie over licenties is relevant voor artikel 15n Auteurswet (text and data mining exceptie).

## Test plan

- [x] Alle bestaande tests passen (20 passed)
- [x] Markdown-tabellen correct geformatteerd

🤖 Generated with [Claude Code](https://claude.com/claude-code)