### PR TITLE
Fix licentielinks: verwijs naar LICENSE in repo

### DIFF
--- a/skills/inet-api/SKILL.md
+++ b/skills/inet-api/SKILL.md
@@ -385,8 +385,8 @@ regelmatig te scannen en trends bij te houden.
 
 | Repository | Beschrijving | Licentie |
 |-----------|-------------|--------|
-| [Internet.nl-API-docs](https://github.com/internetstandards/Internet.nl-API-docs) | Officieel API-documentatie | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) |
-| [Internet.nl](https://github.com/internetstandards/Internet.nl) | Testsuite broncode | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) |
+| [Internet.nl-API-docs](https://github.com/internetstandards/Internet.nl-API-docs) | Officieel API-documentatie | [CC-BY-4.0](https://github.com/internetstandards/Internet.nl-API-docs/blob/main/LICENSE-CC-BY-4.0.txt) |
+| [Internet.nl](https://github.com/internetstandards/Internet.nl) | Testsuite broncode | [Apache-2.0](https://github.com/internetstandards/Internet.nl/blob/main/LICENSE-Apache-2.0.txt) |
 
 ## Veelvoorkomende problemen
 

--- a/skills/inet-mail/SKILL.md
+++ b/skills/inet-mail/SKILL.md
@@ -273,8 +273,8 @@ dig MX example.nl +dnssec +short
 
 | Repository | Beschrijving | Licentie |
 |-----------|-------------|--------|
-| [Internet.nl](https://github.com/internetstandards/Internet.nl) | Testsuite broncode | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) |
-| [toolbox-wiki](https://github.com/internetstandards/toolbox-wiki) | Implementatiegidsen | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) |
+| [Internet.nl](https://github.com/internetstandards/Internet.nl) | Testsuite broncode | [Apache-2.0](https://github.com/internetstandards/Internet.nl/blob/main/LICENSE-Apache-2.0.txt) |
+| [toolbox-wiki](https://github.com/internetstandards/toolbox-wiki) | Implementatiegidsen | [CC-BY-4.0](https://github.com/internetstandards/toolbox-wiki/blob/main/LICENSE-CC-BY-4.0.txt) |
 
 ## Veelvoorkomende problemen
 

--- a/skills/inet-toolbox/SKILL.md
+++ b/skills/inet-toolbox/SKILL.md
@@ -388,8 +388,8 @@ ping6 example.nl
 
 | Repository | Beschrijving | Licentie |
 |-----------|-------------|--------|
-| [toolbox-wiki](https://github.com/internetstandards/toolbox-wiki) | Implementatiegidsen (bronmateriaal) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) |
-| [Internet.nl](https://github.com/internetstandards/Internet.nl) | Testsuite om resultaat te controleren | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) |
+| [toolbox-wiki](https://github.com/internetstandards/toolbox-wiki) | Implementatiegidsen (bronmateriaal) | [CC-BY-4.0](https://github.com/internetstandards/toolbox-wiki/blob/main/LICENSE-CC-BY-4.0.txt) |
+| [Internet.nl](https://github.com/internetstandards/Internet.nl) | Testsuite om resultaat te controleren | [Apache-2.0](https://github.com/internetstandards/Internet.nl/blob/main/LICENSE-Apache-2.0.txt) |
 
 ## Veelvoorkomende problemen
 

--- a/skills/inet-web/SKILL.md
+++ b/skills/inet-web/SKILL.md
@@ -298,8 +298,8 @@ curl -s "https://stat.ripe.net/data/rpki-validation/data.json?resource=${ip}" | 
 
 | Repository | Beschrijving | Licentie |
 |-----------|-------------|--------|
-| [Internet.nl](https://github.com/internetstandards/Internet.nl) | Testsuite broncode (Python/Django) | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) |
-| [toolbox-wiki](https://github.com/internetstandards/toolbox-wiki) | Implementatiegidsen per standaard | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) |
+| [Internet.nl](https://github.com/internetstandards/Internet.nl) | Testsuite broncode (Python/Django) | [Apache-2.0](https://github.com/internetstandards/Internet.nl/blob/main/LICENSE-Apache-2.0.txt) |
+| [toolbox-wiki](https://github.com/internetstandards/toolbox-wiki) | Implementatiegidsen per standaard | [CC-BY-4.0](https://github.com/internetstandards/toolbox-wiki/blob/main/LICENSE-CC-BY-4.0.txt) |
 
 ## Veelvoorkomende problemen
 

--- a/skills/inet/SKILL.md
+++ b/skills/inet/SKILL.md
@@ -80,9 +80,9 @@ De broncode en documentatie staan onder de GitHub-organisatie
 
 | Repository | Beschrijving | Licentie |
 |-----------|-------------|--------|
-| [Internet.nl](https://github.com/internetstandards/Internet.nl) | De internet.nl testsuite (Python/Django) | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) |
-| [Internet.nl-API-docs](https://github.com/internetstandards/Internet.nl-API-docs) | Documentatie voor de batch API (v2) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) |
-| [toolbox-wiki](https://github.com/internetstandards/toolbox-wiki) | Implementatiegidsen per standaard en platform | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) |
+| [Internet.nl](https://github.com/internetstandards/Internet.nl) | De internet.nl testsuite (Python/Django) | [Apache-2.0](https://github.com/internetstandards/Internet.nl/blob/main/LICENSE-Apache-2.0.txt) |
+| [Internet.nl-API-docs](https://github.com/internetstandards/Internet.nl-API-docs) | Documentatie voor de batch API (v2) | [CC-BY-4.0](https://github.com/internetstandards/Internet.nl-API-docs/blob/main/LICENSE-CC-BY-4.0.txt) |
+| [toolbox-wiki](https://github.com/internetstandards/toolbox-wiki) | Implementatiegidsen per standaard en platform | [CC-BY-4.0](https://github.com/internetstandards/toolbox-wiki/blob/main/LICENSE-CC-BY-4.0.txt) |
 
 ## Handige commando's voor repo-exploratie
 


### PR DESCRIPTION
## Summary

- Vervang generieke licentie-URL's (apache.org, creativecommons.org) door directe links naar de LICENSE-bestanden in de respectievelijke GitHub-repositories
- Internet.nl: `LICENSE-Apache-2.0.txt` op de main branch
- Internet.nl-API-docs: `LICENSE-CC-BY-4.0.txt` op de main branch
- toolbox-wiki: `LICENSE-CC-BY-4.0.txt` op de main branch

Aangepaste bestanden:
- `skills/inet/SKILL.md`
- `skills/inet-api/SKILL.md`
- `skills/inet-mail/SKILL.md`
- `skills/inet-web/SKILL.md`
- `skills/inet-toolbox/SKILL.md`

## Test plan

- [x] `uv run pytest` uitgevoerd: 58 tests geslaagd