### PR TITLE
Voeg dual-license toe voor Internet.nl (Apache-2.0 + CC-BY-4.0)

### DIFF
--- a/skills/inet-api/SKILL.md
+++ b/skills/inet-api/SKILL.md
@@ -386,7 +386,7 @@ regelmatig te scannen en trends bij te houden.
 | Repository | Beschrijving | Licentie |
 |-----------|-------------|--------|
 | [Internet.nl-API-docs](https://github.com/internetstandards/Internet.nl-API-docs) | Officieel API-documentatie | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) |
-| [Internet.nl](https://github.com/internetstandards/Internet.nl) | Testsuite broncode | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) |
+| [Internet.nl](https://github.com/internetstandards/Internet.nl) | Testsuite broncode | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) (code), [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) (vertalingen) |
 
 ## Veelvoorkomende problemen
 

--- a/skills/inet-mail/SKILL.md
+++ b/skills/inet-mail/SKILL.md
@@ -273,7 +273,7 @@ dig MX example.nl +dnssec +short
 
 | Repository | Beschrijving | Licentie |
 |-----------|-------------|--------|
-| [Internet.nl](https://github.com/internetstandards/Internet.nl) | Testsuite broncode | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) |
+| [Internet.nl](https://github.com/internetstandards/Internet.nl) | Testsuite broncode | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) (code), [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) (vertalingen) |
 | [toolbox-wiki](https://github.com/internetstandards/toolbox-wiki) | Implementatiegidsen | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) |
 
 ## Veelvoorkomende problemen

--- a/skills/inet-toolbox/SKILL.md
+++ b/skills/inet-toolbox/SKILL.md
@@ -389,7 +389,7 @@ ping6 example.nl
 | Repository | Beschrijving | Licentie |
 |-----------|-------------|--------|
 | [toolbox-wiki](https://github.com/internetstandards/toolbox-wiki) | Implementatiegidsen (bronmateriaal) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) |
-| [Internet.nl](https://github.com/internetstandards/Internet.nl) | Testsuite om resultaat te controleren | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) |
+| [Internet.nl](https://github.com/internetstandards/Internet.nl) | Testsuite om resultaat te controleren | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) (code), [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) (vertalingen) |
 
 ## Veelvoorkomende problemen
 

--- a/skills/inet-web/SKILL.md
+++ b/skills/inet-web/SKILL.md
@@ -298,7 +298,7 @@ curl -s "https://stat.ripe.net/data/rpki-validation/data.json?resource=${ip}" | 
 
 | Repository | Beschrijving | Licentie |
 |-----------|-------------|--------|
-| [Internet.nl](https://github.com/internetstandards/Internet.nl) | Testsuite broncode (Python/Django) | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) |
+| [Internet.nl](https://github.com/internetstandards/Internet.nl) | Testsuite broncode (Python/Django) | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) (code), [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) (vertalingen) |
 | [toolbox-wiki](https://github.com/internetstandards/toolbox-wiki) | Implementatiegidsen per standaard | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) |
 
 ## Veelvoorkomende problemen

--- a/skills/inet/SKILL.md
+++ b/skills/inet/SKILL.md
@@ -80,7 +80,7 @@ De broncode en documentatie staan onder de GitHub-organisatie
 
 | Repository | Beschrijving | Licentie |
 |-----------|-------------|--------|
-| [Internet.nl](https://github.com/internetstandards/Internet.nl) | De internet.nl testsuite (Python/Django) | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) |
+| [Internet.nl](https://github.com/internetstandards/Internet.nl) | De internet.nl testsuite (Python/Django) | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) (code), [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) (vertalingen) |
 | [Internet.nl-API-docs](https://github.com/internetstandards/Internet.nl-API-docs) | Documentatie voor de batch API (v2) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) |
 | [toolbox-wiki](https://github.com/internetstandards/toolbox-wiki) | Implementatiegidsen per standaard en platform | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode.en) |
 


### PR DESCRIPTION
## Summary

- Internet.nl repo gebruikt een dual-license: Apache-2.0 voor code, CC-BY-4.0 voor vertalingen (conform `LICENSE.spdx`)
- Voorheen werd in alle SKILL.md bestanden alleen Apache-2.0 vermeld
- Nu correct weergegeven als "Apache-2.0 (code), CC-BY-4.0 (vertalingen)"

## Gewijzigde bestanden

- `skills/inet/SKILL.md`
- `skills/inet-web/SKILL.md`
- `skills/inet-mail/SKILL.md`
- `skills/inet-toolbox/SKILL.md`
- `skills/inet-api/SKILL.md`

## Test plan

- [ ] Controleer dat de licentielinks werken
- [ ] Verify consistentie met `conflicts.md` (die al correct de dual-license documenteerde)