### PR TITLE
Update disclaimer: Overheidsbreed standpunt i.p.v. Rijksbrede beleidskader

### DIFF
--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -20,11 +20,7 @@ Bij twijfel of tegenstrijdigheid geldt altijd de officiële, gepubliceerde versi
 
 ## Gebruik van generatieve AI
 
-Overheidsorganisaties die generatieve AI inzetten — waaronder het gebruik van deze plugin en de output die ermee wordt gegenereerd — dienen te voldoen aan het [Rijksbrede beleidskader voor de inzet van generatieve AI](https://www.government.nl/documents/policy-notes/2025/01/31/government-wide-position-on-the-use-of-generative-ai). Dit betekent onder meer:
-
-- AI-gegenereerde antwoorden dienen altijd te worden geverifieerd aan de hand van de officiële bronnen
-- De verantwoordelijkheid voor het gebruik van de output ligt bij de gebruiker
-- Deze plugin vervangt geen juridisch, beleidsmatig of technisch advies
+Overheidsorganisaties die generatieve AI inzetten — waaronder het gebruik van deze plugin en de output die ermee wordt gegenereerd — dienen te voldoen aan het [Overheidsbreed standpunt voor de inzet van generatieve AI](https://open.overheid.nl/documenten/bc03ce31-0cf1-4946-9c94-e934a62ebe73/file) en aan eigen beleid en kaders over AI.
 
 ## Geen garantie
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Deze plugin is onderdeel van de [skills-marketplace](https://github.com/develope
 
 ## Disclaimer
 
-**Deze plugin is geen officieel product van [internet.nl](https://internet.nl).** Het is een experimenteel project van [developer.overheid.nl](https://developer.overheid.nl), gebaseerd op publiek beschikbare standaarden en documentatie. De skills zijn informatieve samenvattingen — **niet** de officiële standaarden zelf. De definities op [Forum Standaardisatie](https://www.forumstandaardisatie.nl/open-standaarden) en [internet.nl](https://internet.nl) zijn altijd leidend. Overheidsorganisaties die generatieve AI inzetten dienen te voldoen aan het [Rijksbrede beleidskader voor generatieve AI](https://www.government.nl/documents/policy-notes/2025/01/31/government-wide-position-on-the-use-of-generative-ai). Zie [DISCLAIMER.md](DISCLAIMER.md) voor de volledige disclaimer.
+**Deze plugin is geen officieel product van [internet.nl](https://internet.nl).** Het is een experimenteel project van [developer.overheid.nl](https://developer.overheid.nl), gebaseerd op publiek beschikbare standaarden en documentatie. De skills zijn informatieve samenvattingen — **niet** de officiële standaarden zelf. De definities op [Forum Standaardisatie](https://www.forumstandaardisatie.nl/open-standaarden) en [internet.nl](https://internet.nl) zijn altijd leidend. Overheidsorganisaties die generatieve AI inzetten dienen te voldoen aan het [Overheidsbreed standpunt voor de inzet van generatieve AI](https://open.overheid.nl/documenten/bc03ce31-0cf1-4946-9c94-e934a62ebe73/file). Zie [DISCLAIMER.md](DISCLAIMER.md) voor de volledige disclaimer.
 
 ---
 

--- a/skills/inet-api/SKILL.md
+++ b/skills/inet-api/SKILL.md
@@ -19,7 +19,7 @@ metadata:
   status: concept
 ---
 
-> **Let op:** Deze skill is geen officieel product van internet.nl. De beschrijvingen zijn informatieve samenvattingen — niet de officiële standaarden zelf. De testcriteria op [internet.nl](https://internet.nl) en de definities op [forumstandaardisatie.nl](https://www.forumstandaardisatie.nl/open-standaarden) zijn altijd leidend. Overheidsorganisaties die generatieve AI inzetten dienen te voldoen aan het [Rijksbrede beleidskader voor generatieve AI](https://www.government.nl/documents/policy-notes/2025/01/31/government-wide-position-on-the-use-of-generative-ai). Zie [DISCLAIMER.md](../../DISCLAIMER.md).
+> **Let op:** Deze skill is geen officieel product van internet.nl. De beschrijvingen zijn informatieve samenvattingen — niet de officiële standaarden zelf. De testcriteria op [internet.nl](https://internet.nl) en de definities op [forumstandaardisatie.nl](https://www.forumstandaardisatie.nl/open-standaarden) zijn altijd leidend. Overheidsorganisaties die generatieve AI inzetten dienen te voldoen aan het [Overheidsbreed standpunt voor de inzet van generatieve AI](https://open.overheid.nl/documenten/bc03ce31-0cf1-4946-9c94-e934a62ebe73/file). Zie [DISCLAIMER.md](../../DISCLAIMER.md).
 
 **Gebruik deze skill wanneer een gebruiker vraagt over de internet.nl batch API,
 het geautomatiseerd scannen van meerdere domeinen, of het bouwen van een

--- a/skills/inet-mail/SKILL.md
+++ b/skills/inet-mail/SKILL.md
@@ -21,7 +21,7 @@ metadata:
   status: concept
 ---
 
-> **Let op:** Deze skill is geen officieel product van internet.nl. De beschrijvingen zijn informatieve samenvattingen — niet de officiële standaarden zelf. De testcriteria op [internet.nl](https://internet.nl) en de definities op [forumstandaardisatie.nl](https://www.forumstandaardisatie.nl/open-standaarden) zijn altijd leidend. Overheidsorganisaties die generatieve AI inzetten dienen te voldoen aan het [Rijksbrede beleidskader voor generatieve AI](https://www.government.nl/documents/policy-notes/2025/01/31/government-wide-position-on-the-use-of-generative-ai). Zie [DISCLAIMER.md](../../DISCLAIMER.md).
+> **Let op:** Deze skill is geen officieel product van internet.nl. De beschrijvingen zijn informatieve samenvattingen — niet de officiële standaarden zelf. De testcriteria op [internet.nl](https://internet.nl) en de definities op [forumstandaardisatie.nl](https://www.forumstandaardisatie.nl/open-standaarden) zijn altijd leidend. Overheidsorganisaties die generatieve AI inzetten dienen te voldoen aan het [Overheidsbreed standpunt voor de inzet van generatieve AI](https://open.overheid.nl/documenten/bc03ce31-0cf1-4946-9c94-e934a62ebe73/file). Zie [DISCLAIMER.md](../../DISCLAIMER.md).
 
 **Gebruik deze skill wanneer een gebruiker vraagt over mailstandaarden die internet.nl test,
 zoals SPF, DKIM, DMARC, STARTTLS of DANE. Genereer correcte DNS-records en diagnostische

--- a/skills/inet-toolbox/SKILL.md
+++ b/skills/inet-toolbox/SKILL.md
@@ -21,7 +21,7 @@ metadata:
   status: concept
 ---
 
-> **Let op:** Deze skill is geen officieel product van internet.nl. De beschrijvingen zijn informatieve samenvattingen — niet de officiële standaarden zelf. De testcriteria op [internet.nl](https://internet.nl) en de definities op [forumstandaardisatie.nl](https://www.forumstandaardisatie.nl/open-standaarden) zijn altijd leidend. Overheidsorganisaties die generatieve AI inzetten dienen te voldoen aan het [Rijksbrede beleidskader voor generatieve AI](https://www.government.nl/documents/policy-notes/2025/01/31/government-wide-position-on-the-use-of-generative-ai). Zie [DISCLAIMER.md](../../DISCLAIMER.md).
+> **Let op:** Deze skill is geen officieel product van internet.nl. De beschrijvingen zijn informatieve samenvattingen — niet de officiële standaarden zelf. De testcriteria op [internet.nl](https://internet.nl) en de definities op [forumstandaardisatie.nl](https://www.forumstandaardisatie.nl/open-standaarden) zijn altijd leidend. Overheidsorganisaties die generatieve AI inzetten dienen te voldoen aan het [Overheidsbreed standpunt voor de inzet van generatieve AI](https://open.overheid.nl/documenten/bc03ce31-0cf1-4946-9c94-e934a62ebe73/file). Zie [DISCLAIMER.md](../../DISCLAIMER.md).
 
 **Gebruik deze skill wanneer een gebruiker vraagt hoe een specifieke internetstandaard
 stap-voor-stap geimplementeerd moet worden. Genereer werkende configuratie voor het

--- a/skills/inet-web/SKILL.md
+++ b/skills/inet-web/SKILL.md
@@ -22,7 +22,7 @@ metadata:
   status: concept
 ---
 
-> **Let op:** Deze skill is geen officieel product van internet.nl. De beschrijvingen zijn informatieve samenvattingen — niet de officiële standaarden zelf. De testcriteria op [internet.nl](https://internet.nl) en de definities op [forumstandaardisatie.nl](https://www.forumstandaardisatie.nl/open-standaarden) zijn altijd leidend. Overheidsorganisaties die generatieve AI inzetten dienen te voldoen aan het [Rijksbrede beleidskader voor generatieve AI](https://www.government.nl/documents/policy-notes/2025/01/31/government-wide-position-on-the-use-of-generative-ai). Zie [DISCLAIMER.md](../../DISCLAIMER.md).
+> **Let op:** Deze skill is geen officieel product van internet.nl. De beschrijvingen zijn informatieve samenvattingen — niet de officiële standaarden zelf. De testcriteria op [internet.nl](https://internet.nl) en de definities op [forumstandaardisatie.nl](https://www.forumstandaardisatie.nl/open-standaarden) zijn altijd leidend. Overheidsorganisaties die generatieve AI inzetten dienen te voldoen aan het [Overheidsbreed standpunt voor de inzet van generatieve AI](https://open.overheid.nl/documenten/bc03ce31-0cf1-4946-9c94-e934a62ebe73/file). Zie [DISCLAIMER.md](../../DISCLAIMER.md).
 
 **Gebruik deze skill wanneer een gebruiker vraagt over webstandaarden die internet.nl test,
 zoals HTTPS/TLS, DNSSEC, IPv6, RPKI, security headers of security.txt. Genereer

--- a/skills/inet/SKILL.md
+++ b/skills/inet/SKILL.md
@@ -18,7 +18,7 @@ metadata:
   status: concept
 ---
 
-> **Let op:** Deze skill is geen officieel product van internet.nl. De beschrijvingen zijn informatieve samenvattingen — niet de officiële standaarden zelf. De testcriteria op [internet.nl](https://internet.nl) en de definities op [forumstandaardisatie.nl](https://www.forumstandaardisatie.nl/open-standaarden) zijn altijd leidend. Overheidsorganisaties die generatieve AI inzetten dienen te voldoen aan het [Rijksbrede beleidskader voor generatieve AI](https://www.government.nl/documents/policy-notes/2025/01/31/government-wide-position-on-the-use-of-generative-ai). Zie [DISCLAIMER.md](../../DISCLAIMER.md).
+> **Let op:** Deze skill is geen officieel product van internet.nl. De beschrijvingen zijn informatieve samenvattingen — niet de officiële standaarden zelf. De testcriteria op [internet.nl](https://internet.nl) en de definities op [forumstandaardisatie.nl](https://www.forumstandaardisatie.nl/open-standaarden) zijn altijd leidend. Overheidsorganisaties die generatieve AI inzetten dienen te voldoen aan het [Overheidsbreed standpunt voor de inzet van generatieve AI](https://open.overheid.nl/documenten/bc03ce31-0cf1-4946-9c94-e934a62ebe73/file). Zie [DISCLAIMER.md](../../DISCLAIMER.md).
 
 **Gebruik deze skill wanneer een gebruiker vraagt naar een overzicht van internetstandaarden,
 naar de internet.nl testsuite in het algemeen, of wanneer niet duidelijk is welke sub-skill


### PR DESCRIPTION
## Summary

- **Naam gewijzigd**: "Rijksbrede beleidskader voor de inzet van generatieve AI" → "Overheidsbreed standpunt voor de inzet van generatieve AI"
- **URL gewijzigd**: naar Nederlandse versie op [open.overheid.nl](https://open.overheid.nl/documenten/bc03ce31-0cf1-4946-9c94-e934a62ebe73/file)
- **Opsomming verwijderd**: de 3 bullet points ("Dit betekent onder meer:") stonden niet in het standpunt zelf
- **Toegevoegd**: "en aan eigen beleid en kaders over AI."

Op verzoek van Vedran Bilanovic. Dezelfde wijziging wordt doorgevoerd in alle 4 repos (marketplace, internet, geo, standaarden).

## Bestanden

- `DISCLAIMER.md` — volledige sectie "Gebruik van generatieve AI" aangepast
- `README.md` — korte disclaimer-verwijzing aangepast
- 5× `skills/*/SKILL.md` — disclaimer-regel bovenaan aangepast

## Test plan

- [x] Geen "Rijksbrede beleidskader" meer in de repo
- [x] Geen "Dit betekent onder meer" meer in de repo
- [x] "Overheidsbreed standpunt" aanwezig in alle 7 bestanden