### PR TITLE
fix: exclude example.nl URLs in path components from monitoring

### DIFF
--- a/scripts/extract_urls.py
+++ b/scripts/extract_urls.py
@@ -30,6 +30,7 @@ EXCLUDE_PATTERNS = [
     re.compile(r"https?://www\.w3\.org/"),
     re.compile(r"https?://your-domain\.nl"),
     re.compile(r"https?://mijn-organisatie\.nl"),
+    re.compile(r"https?://[^/]+/.*example\.(com|nl|org)"),
 ]
 
 # Markdown-extractie regex: vindt alle URLs in tekst


### PR DESCRIPTION
## Summary

- Voegt een exclude-patroon toe aan `extract_urls.py` dat URLs met `example.nl` (en `.com`/`.org`) als pad-component uitsluit van monitoring
- Voorheen werden alleen URLs met `example.nl` als domein uitgesloten, maar `https://internet.nl/site/example.nl/12345/` werd wel opgepikt
- Nieuw patroon: `https?://[^/]+/.*example\.(com|nl|org)`

## Test plan

- [ ] Controleer dat `https://internet.nl/site/example.nl/12345/` nu wordt uitgesloten
- [ ] Controleer dat legitieme internet.nl URLs nog steeds worden opgepikt
- [ ] `uv run pytest -v` slaagt