### PR TITLE
fix: verbreed Liferay AUI IIFE normalisatie

### DIFF
--- a/scripts/monitor_content.py
+++ b/scripts/monitor_content.py
@@ -117,8 +117,8 @@ def normalize_html(html: str) -> str:
         html,
         flags=re.DOTALL,
     )
-    # Liferay CMS: AUI IIFE script blokken (verschijnen intermittent, variërend per request)
-    # Matcht alle (function() {var $ = AUI.$ ...})(); patronen (Sharing, ratings, socialBookmarks, etc.)
+    # Liferay CMS: AUI IIFE script blokken (intermittent per request)
+    # Matcht alle (function() {var $ = AUI.$ ...})(); patronen
     # Variant 1: eigen <script> tag (volledige tag verwijderen)
     html = re.sub(
         r"<script[^>]*>\s*\(function\(\)\s*\{var \$ = AUI\.\$"


### PR DESCRIPTION
## Samenvatting

- Verbreed `normalize_html()` Liferay AUI IIFE regex: strip **alle** `(function() {var $ = AUI.$ ...})();` patronen, niet alleen de Sharing-variant
- Cross-repo fix: zelfde wijziging als in skills-geo en skills-standaarden

## Test plan

- [x] `uv run pytest -v` slaagt
- [ ] CI groen