### PR TITLE
feat: voeg ACME (RFC 8555) toe aan webstandaarden

### DIFF
--- a/skills/inet/SKILL.md
+++ b/skills/inet/SKILL.md
@@ -61,6 +61,7 @@ De standaarden staan op de
 | Security headers | Getest door internet.nl (geen Forum status) | CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy |
 | security.txt | Verplicht (pas-toe-of-leg-uit) | Contactinformatie voor beveiligingsonderzoekers (RFC 9116) |
 | RPKI | Verplicht (pas-toe-of-leg-uit) | Route Origin Validation, beschermt BGP-routing |
+| ACME | Verplicht (pas-toe-of-leg-uit) | Automated Certificate Management Environment (RFC 8555), automatisch aanvragen en vernieuwen van TLS-certificaten |
 
 ### Mailstandaarden
 


### PR DESCRIPTION
## Samenvatting

- ACME (RFC 8555) toegevoegd aan de webstandaarden tabel in inet/SKILL.md
- ACME staat sinds 23-09-2025 op de pas-toe-of-leg-uit-lijst van Forum Standaardisatie
- Automatiseert aanvragen en vernieuwen van TLS-certificaten

## Aanleiding

Monitoring issues #88-#98 — forumstandaardisatie.nl content wijziging gecontroleerd, ACME ontbrak in skill-content.