### PR TITLE
fix: revert ACME toevoeging - valt buiten internet.nl scope

### DIFF
--- a/skills/inet/SKILL.md
+++ b/skills/inet/SKILL.md
@@ -61,7 +61,6 @@ De standaarden staan op de
 | Security headers | Getest door internet.nl (geen Forum status) | CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy |
 | security.txt | Verplicht (pas-toe-of-leg-uit) | Contactinformatie voor beveiligingsonderzoekers (RFC 9116) |
 | RPKI | Verplicht (pas-toe-of-leg-uit) | Route Origin Validation, beschermt BGP-routing |
-| ACME | Verplicht (pas-toe-of-leg-uit) | Automated Certificate Management Environment (RFC 8555), automatisch aanvragen en vernieuwen van TLS-certificaten |
 
 ### Mailstandaarden
 


### PR DESCRIPTION
## Samenvatting

- Revert van #99 (ACME toevoeging aan webstandaarden overzicht)
- ACME (RFC 8555) staat op de pas-toe-of-leg-uit-lijst, maar wordt niet door internet.nl getest
- Deze plugin beschrijft standaarden die internet.nl test; ACME hoort thuis in de overkoepelende NeRDS-skills (developer-overheid-nl-agent-skills)