### PR TITLE
fix: strip Drupal /uploads/ dynamische elementen in normalize_html

### DIFF
--- a/scripts/monitor_content.py
+++ b/scripts/monitor_content.py
@@ -96,6 +96,25 @@ def normalize_html(html: str) -> str:
     html = re.sub(r"js-view-dom-id-[a-f0-9]+", "js-view-dom-id-HASH", html)
     # Drupal CMS: permissionsHash (verandert bij module/permissie updates)
     html = re.sub(r'"permissionsHash":"[a-f0-9]+"', '"permissionsHash":"HASH"', html)
+    # Drupal CMS: aggregatie filenames via /uploads/ pad (alternatief voor /sites/default/files/)
+    html = re.sub(
+        r"/uploads/css/css_[A-Za-z0-9_-]+\.css",
+        "/uploads/css/css_HASH.css",
+        html,
+    )
+    html = re.sub(
+        r"/uploads/js/js_[A-Za-z0-9_-]+\.js",
+        "/uploads/js/js_HASH.js",
+        html,
+    )
+    # Drupal CMS: ajaxPageState.libraries (base64-encoded library list, verandert bij cache rebuild)
+    html = re.sub(
+        r'"libraries":"[A-Za-z0-9+/=_-]+"',
+        '"libraries":"HASH"',
+        html,
+    )
+    # Drupal CMS: form_action CSRF tokens in ajaxTrustedUrl (veranderen bij cache rebuild)
+    html = re.sub(r"form_action_[A-Za-z0-9_-]+", "form_action_HASH", html)
     # Next.js RSC streaming: inline data scripts veranderen chunking per request
     html = re.sub(r"<script\s*>self\.__next_f\.push\([^<]*\)</script>", "", html)
     # Sentry tracing: trace-id en baggage veranderen per request


### PR DESCRIPTION
## Samenvatting

Drupal CMS false positives opgelost in de content monitoring. Vier patronen die bij cache rebuilds veranderen worden nu genormaliseerd:
- `/uploads/css/` en `/uploads/js/` aggregatie filenames
- `ajaxPageState.libraries` (base64-encoded library list)
- `form_action_*` CSRF tokens in `ajaxTrustedUrl`

Identieke fix doorgevoerd in skills-geo, skills-standaarden en skills-nora.