### PR TITLE
fix: strip Liferay importmap script blokken in normalize_html()

### DIFF
--- a/scripts/monitor_content.py
+++ b/scripts/monitor_content.py
@@ -154,6 +154,13 @@ def normalize_html(html: str) -> str:
         html,
         flags=re.DOTALL,
     )
+    # Liferay CMS: importmap script blokken (key-volgorde varieert per backend server)
+    html = re.sub(
+        r'<script\s+type="importmap">\s*\{.*?\}\s*</script>',
+        "",
+        html,
+        flags=re.DOTALL,
+    )
     # Liferay CMS: p_p_auth tokens in URLs (variëren per request/server)
     html = re.sub(r"p_p_auth=[A-Za-z0-9_-]+", "p_p_auth=TOKEN", html)
     # Apache directory listings: timestamps variëren bij server-deployments


### PR DESCRIPTION
## Samenvatting

- Strip `<script type="importmap">` blokken in `normalize_html()` — de key-volgorde in de JSON varieert per Liferay backend server, wat false positive monitoring issues veroorzaakt