### PR TITLE
fix: vervang normalize_html() door extract_visible_text()

### DIFF
--- a/scripts/monitor_content.py
+++ b/scripts/monitor_content.py
@@ -64,110 +64,25 @@ def fetch_with_retry(
     return None
 
 
-def normalize_html(html: str) -> str:
-    """Normaliseer HTML body door dynamische elementen te strippen."""
-    # Verwijder timestamps en datum-achtige patronen
-    html = re.sub(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[^\s\"'<]*", "", html)
-    # Verwijder generator meta-tags
-    html = re.sub(r'<meta\s+name="generator"[^>]*>', "", html)
-    # Verwijder nonces (HTML-attributen, JS-assignments en escaped JSON)
-    html = re.sub(r'nonce="[^"]*"', "", html)
-    html = re.sub(r'\.nonce\s*=\s*"[^"]*"', '.nonce = ""', html)
-    # Next.js/React escaped JSON nonces: \"nonce\":\"base64value\"
-    html = re.sub(r'\\"nonce\\":\\"[^"\\]*\\"', r'\\"nonce\\":\\"NONCE\\"', html)
-    # Verwijder ReSpec-specifieke build timestamps
-    html = re.sub(r"respecVersion\s*=\s*['\"][^'\"]*['\"]", "", html)
-    # Verwijder HTML comments (build hashes, timestamps, etc.)
-    html = re.sub(r"<!--.*?-->", "", html, flags=re.DOTALL)
-    # Verwijder cache-busting query params in script/link/img tags
-    html = re.sub(r'(\.(js|css|png|svg|ico))\?[^"\'>\s]+', r"\1", html)
-    # Drupal CMS: aggregatie filenames met content-hashes (veranderen bij cache rebuild)
-    html = re.sub(
-        r"/sites/default/files/css/css_[A-Za-z0-9_-]+\.css",
-        "/sites/default/files/css/css_HASH.css",
-        html,
-    )
-    html = re.sub(
-        r"/sites/default/files/js/js_[A-Za-z0-9_-]+\.js",
-        "/sites/default/files/js/js_HASH.js",
-        html,
-    )
-    # Drupal CMS: view DOM IDs (veranderen bij cache rebuild)
-    html = re.sub(r"js-view-dom-id-[a-f0-9]+", "js-view-dom-id-HASH", html)
-    # Drupal CMS: permissionsHash (verandert bij module/permissie updates)
-    html = re.sub(r'"permissionsHash":"[a-f0-9]+"', '"permissionsHash":"HASH"', html)
-    # Drupal CMS: aggregatie filenames via /uploads/ pad (alternatief voor /sites/default/files/)
-    html = re.sub(
-        r"/uploads/css/css_[A-Za-z0-9_-]+\.css",
-        "/uploads/css/css_HASH.css",
-        html,
-    )
-    html = re.sub(
-        r"/uploads/js/js_[A-Za-z0-9_-]+\.js",
-        "/uploads/js/js_HASH.js",
-        html,
-    )
-    # Drupal CMS: ajaxPageState.libraries (base64-encoded library list, verandert bij cache rebuild)
-    html = re.sub(
-        r'"libraries":"[A-Za-z0-9+/=_-]+"',
-        '"libraries":"HASH"',
-        html,
-    )
-    # Drupal CMS: form_action CSRF tokens in ajaxTrustedUrl (veranderen bij cache rebuild)
-    html = re.sub(r"form_action_[A-Za-z0-9_-]+", "form_action_HASH", html)
-    # Next.js RSC streaming: inline data scripts veranderen chunking per request
-    html = re.sub(r"<script\s*>self\.__next_f\.push\([^<]*\)</script>", "", html)
-    # Sentry tracing: trace-id en baggage veranderen per request
-    html = re.sub(r'<meta\s+name="sentry-trace"[^>]*>', "", html)
-    html = re.sub(r'<meta\s+name="baggage"\s+content="sentry-[^"]*"[^>]*>', "", html)
-    # Liferay CMS: authToken / p_auth CSRF token (verandert per request)
-    html = re.sub(r"Liferay\.authToken\s*=\s*'[^']*'", "Liferay.authToken = 'TOKEN'", html)
-    html = re.sub(r'name="p_auth"\s+value="[^"]*"', 'name="p_auth" value="TOKEN"', html)
-    # Liferay CMS: cache-bust timestamp op resource URLs (bijv. ?t=1771832749422 of &t=...)
-    html = re.sub(r"[?&]t=\d{10,15}", "?t=TIMESTAMP", html)
-    # Liferay CMS: HTML-encoded cache-bust timestamps (&amp;t=DIGITS in combo servlet URLs)
-    html = re.sub(r"&amp;t=\d{10,15}", "&amp;t=TIMESTAMP", html)
-    # Liferay CMS: dynamische hex IDs op link/style elementen (variëren tussen backend servers)
-    html = re.sub(r' id="[a-f0-9]{6,10}"', ' id="HEXID"', html)
-    # Liferay CMS: AUI module config blokken (variëren tussen backend servers)
-    html = re.sub(
-        r"<script[^>]*>\s*try\s*\{var MODULE_MAIN=.*?</script>",
-        "",
-        html,
-        flags=re.DOTALL,
-    )
-    # Liferay CMS: AUI IIFE script blokken (intermittent per request)
-    # Matcht alle (function() {var $ = AUI.$ ...})(); patronen
-    # Variant 1: eigen <script> tag (volledige tag verwijderen)
-    html = re.sub(
-        r"<script[^>]*>\s*\(function\(\)\s*\{var \$ = AUI\.\$"
-        r".*?\}\)\(\);\s*</script>",
-        "",
-        html,
-        flags=re.DOTALL,
-    )
-    # Variant 2: ingebed in groter script blok (alleen de IIFE verwijderen)
-    html = re.sub(
-        r"\(function\(\)\s*\{var \$ = AUI\.\$"
-        r".*?\}\)\(\);",
-        "",
-        html,
-        flags=re.DOTALL,
-    )
-    # Liferay CMS: importmap script blokken (key-volgorde varieert per backend server)
-    html = re.sub(
-        r'<script\s+type="importmap">\s*\{.*?\}\s*</script>',
-        "",
-        html,
-        flags=re.DOTALL,
-    )
-    # Liferay CMS: p_p_auth tokens in URLs (variëren per request/server)
-    html = re.sub(r"p_p_auth=[A-Za-z0-9_-]+", "p_p_auth=TOKEN", html)
-    # Apache directory listings: timestamps variëren bij server-deployments
-    html = re.sub(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}\s+", "", html)
-    # Normaliseer opeenvolgende lege regels (variëren tussen requests bij sommige CMS'en)
-    html = re.sub(r"\n{3,}", "\n\n", html)
-    return html
+def extract_visible_text(html: str) -> str:
+    """Extraheer alleen de zichtbare tekst uit HTML.
+
+    Verwijdert alle scripts, styles, HTML-tags en normaliseert whitespace.
+    Dit is robuust tegen CMS-framework wijzigingen (Drupal cache rebuilds,
+    Liferay token rotatie, etc.) omdat alleen de leesbare content overblijft.
+    """
+    # Gebruik alleen de <body> als die er is
+    body_match = re.search(r"<body[^>]*>(.*)</body>", html, flags=re.DOTALL)
+    text = body_match.group(1) if body_match else html
+    # Verwijder niet-zichtbare elementen
+    text = re.sub(r"<script[^>]*>.*?</script>", " ", text, flags=re.DOTALL)
+    text = re.sub(r"<style[^>]*>.*?</style>", " ", text, flags=re.DOTALL)
+    text = re.sub(r"<noscript[^>]*>.*?</noscript>", " ", text, flags=re.DOTALL)
+    # Verwijder alle HTML-tags
+    text = re.sub(r"<[^>]+>", " ", text)
+    # Normaliseer whitespace
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
 
 
 def check_github_repo(url: str) -> dict:
@@ -231,8 +146,8 @@ def check_http_resource(url: str, hash_body: bool = True) -> dict:
         result["last_modified"] = resp.headers["Last-Modified"]
 
     if hash_body and resp.text:
-        normalized = normalize_html(resp.text)
-        result["body_sha256"] = hashlib.sha256(normalized.encode()).hexdigest()
+        visible_text = extract_visible_text(resp.text)
+        result["body_sha256"] = hashlib.sha256(visible_text.encode()).hexdigest()
 
     return result
 

--- a/tests/test_monitor_content.py
+++ b/tests/test_monitor_content.py
@@ -71,12 +71,7 @@ class TestExtractVisibleText:
 
     def test_liferay_framework_ruis_genegeerd(self):
         """Liferay tokens en config verdwijnen omdat ze in script-tags zitten."""
-        html = (
-            "<body>"
-            "<script>Liferay.authToken = '9zmfQSYt';</script>"
-            "<p>PDOK content</p>"
-            "</body>"
-        )
+        html = "<body><script>Liferay.authToken = '9zmfQSYt';</script><p>PDOK content</p></body>"
         result = extract_visible_text(html)
         assert "PDOK content" in result
         assert "authToken" not in result

--- a/tests/test_monitor_content.py
+++ b/tests/test_monitor_content.py
@@ -8,111 +8,100 @@ import responses
 from monitor_content import (
     check_http_resource,
     detect_changes,
+    extract_visible_text,
     fetch_with_retry,
-    normalize_html,
 )
 
-# --- normalize_html() ---
+# --- extract_visible_text() ---
 
 
-class TestNormalizeHtml:
-    def test_timestamps_verwijderd(self):
-        html = "<span>Laatste update: 2024-01-15T12:00:00Z</span>"
-        result = normalize_html(html)
-        assert "2024-01-15" not in result
-        assert "<span>" in result
+class TestExtractVisibleText:
+    def test_body_tekst_behouden(self):
+        html = "<html><body><h1>Titel</h1><p>Standaard tekst.</p></body></html>"
+        result = extract_visible_text(html)
+        assert "Titel" in result
+        assert "Standaard tekst." in result
 
-    def test_nonces_html_attributen(self):
-        html = '<script nonce="abc123">console.log("test")</script>'
-        result = normalize_html(html)
-        assert 'nonce="abc123"' not in result
-        assert "console.log" in result
+    def test_scripts_verwijderd(self):
+        html = '<body><p>content</p><script>var x = "secret";</script></body>'
+        result = extract_visible_text(html)
+        assert "content" in result
+        assert "secret" not in result
 
-    def test_nonces_js_assignments(self):
-        html = 'element.nonce = "xyz789"'
-        result = normalize_html(html)
-        assert "xyz789" not in result
-        assert '.nonce = ""' in result
+    def test_styles_verwijderd(self):
+        html = "<body><style>.cls { color: red; }</style><p>zichtbaar</p></body>"
+        result = extract_visible_text(html)
+        assert "zichtbaar" in result
+        assert "color" not in result
 
-    def test_nonces_escaped_json(self):
-        """Next.js/React escaped JSON nonces (NCSC.nl pattern)."""
+    def test_noscript_verwijderd(self):
+        html = "<body><noscript>JS required</noscript><p>content</p></body>"
+        result = extract_visible_text(html)
+        assert "content" in result
+        assert "JS required" not in result
+
+    def test_html_tags_verwijderd(self):
+        html = '<body><div class="wrapper"><a href="/link">tekst</a></div></body>'
+        result = extract_visible_text(html)
+        assert "tekst" in result
+        assert "<div" not in result
+        assert "href" not in result
+
+    def test_whitespace_genormaliseerd(self):
+        html = "<body><p>veel   spaties</p>\n\n\n<p>en  regels</p></body>"
+        result = extract_visible_text(html)
+        assert "veel spaties" in result
+        assert "en regels" in result
+        assert "\n" not in result
+
+    def test_drupal_framework_ruis_genegeerd(self):
+        """CMS-framework code verdwijnt omdat het in script-tags zit."""
         html = (
-            r":HL[\"/_next/static/css/file.css\","
-            r"\"style\",{\"nonce\":\"NGZjMWJjZmYtYTY4MS00YzIx\"}]"
+            "<body>"
+            '<script data-drupal-selector="drupal-settings-json">'
+            '{"ajaxPageState":{"libraries":"eJxdzUEOAi"}}'
+            "</script>"
+            "<p>Echte content</p>"
+            "</body>"
         )
-        result = normalize_html(html)
-        assert "NGZjMWJjZmYtYTY4MS00YzIx" not in result
-        assert r"\"nonce\":\"NONCE\"" in result
+        result = extract_visible_text(html)
+        assert "Echte content" in result
+        assert "ajaxPageState" not in result
+        assert "libraries" not in result
 
-    def test_nextjs_rsc_inline_scripts(self):
-        """Next.js RSC inline data scripts worden gestript (chunking varieert per request)."""
-        html = '<div>content</div><script >self.__next_f.push([1,"1e:data"])</script><p>more</p>'
-        result = normalize_html(html)
-        assert "self.__next_f" not in result
-        assert "<div>content</div>" in result
-        assert "<p>more</p>" in result
+    def test_liferay_framework_ruis_genegeerd(self):
+        """Liferay tokens en config verdwijnen omdat ze in script-tags zitten."""
+        html = (
+            "<body>"
+            "<script>Liferay.authToken = '9zmfQSYt';</script>"
+            "<p>PDOK content</p>"
+            "</body>"
+        )
+        result = extract_visible_text(html)
+        assert "PDOK content" in result
+        assert "authToken" not in result
 
-    def test_html_comments_verwijderd(self):
-        html = "<div><!-- build hash: abc123 --><p>content</p></div>"
-        result = normalize_html(html)
-        assert "build hash" not in result
-        assert "<p>content</p>" in result
+    def test_zonder_body_tag(self):
+        """Werkt ook als er geen <body> tag is (bijv. plain HTML fragment)."""
+        html = "<h1>Titel</h1><p>Tekst</p>"
+        result = extract_visible_text(html)
+        assert "Titel" in result
+        assert "Tekst" in result
 
-    def test_multiline_comments(self):
-        html = "<div><!--\nmultiline\ncomment\n--><p>ok</p></div>"
-        result = normalize_html(html)
-        assert "multiline" not in result
-        assert "<p>ok</p>" in result
-
-    def test_cache_busters_verwijderd(self):
-        html = '<script src="app.js?v=abc123"></script>'
-        result = normalize_html(html)
-        assert "?v=abc123" not in result
-        assert "app.js" in result
-
-    def test_css_cache_busters(self):
-        html = '<link href="style.css?hash=def456">'
-        result = normalize_html(html)
-        assert "?hash=def456" not in result
-        assert "style.css" in result
-
-    def test_generator_meta_verwijderd(self):
-        html = '<meta name="generator" content="ReSpec 1.0">'
-        result = normalize_html(html)
-        assert "generator" not in result
-
-    def test_respec_version_verwijderd(self):
-        html = "var respecVersion = '35.0.2'"
-        result = normalize_html(html)
-        assert "35.0.2" not in result
-
-    def test_drupal_css_aggregatie(self):
-        html = '<link href="/sites/default/files/css/css_US753fRZjubynpaAuOsRw3D.css">'
-        result = normalize_html(html)
-        assert "US753fRZ" not in result
-        assert "css_HASH.css" in result
-
-    def test_drupal_js_aggregatie(self):
-        html = '<script src="/sites/default/files/js/js_Abc123XYZ_def456.js"></script>'
-        result = normalize_html(html)
-        assert "Abc123XYZ" not in result
-        assert "js_HASH.js" in result
-
-    def test_drupal_view_dom_id(self):
-        html = '<div class="js-view-dom-id-56cf8948b068a635455604d548fcf9d2039b62fd">'
-        result = normalize_html(html)
-        assert "56cf8948" not in result
-        assert "js-view-dom-id-HASH" in result
-
-    def test_drupal_permissions_hash(self):
-        html = '{"user":{"uid":0,"permissionsHash":"c838df03955022ed860389a1310a7a71"}}'
-        result = normalize_html(html)
-        assert "c838df03" not in result
-        assert '"permissionsHash":"HASH"' in result
-
-    def test_gewone_content_behouden(self):
-        html = "<h1>Digikoppeling Architectuur</h1><p>Standaard tekst.</p>"
-        assert normalize_html(html) == html
+    def test_multiline_script(self):
+        html = (
+            "<body>"
+            "<script>\n"
+            "  var config = {\n"
+            '    token: "abc123"\n'
+            "  };\n"
+            "</script>"
+            "<p>content</p>"
+            "</body>"
+        )
+        result = extract_visible_text(html)
+        assert "content" in result
+        assert "token" not in result
 
 
 # --- detect_changes() ---
@@ -304,7 +293,7 @@ class TestCheckHttpResource:
         result = check_http_resource("https://test.com/doc")
         assert result["etag"] == '"abc123"'
         assert result["last_modified"] == "Mon, 01 Jan 2024 00:00:00 GMT"
-        expected_hash = hashlib.sha256(normalize_html(body).encode()).hexdigest()
+        expected_hash = hashlib.sha256(extract_visible_text(body).encode()).hexdigest()
         assert result["body_sha256"] == expected_hash
 
     @responses.activate


### PR DESCRIPTION
## Samenvatting

- Vervangt `normalize_html()` (~100 regels CMS-specifieke regexes) door `extract_visible_text()` (~15 regels)
- Hasht alleen de zichtbare tekst (geen scripts, styles, HTML-tags) in plaats van de volledige genormaliseerde HTML
- Elimineert structureel false positives door CMS-framework wijzigingen

Identieke wijziging als in skills-geo en skills-standaarden.

## Test plan

- [x] Alle bestaande tests geüpdatet en slagen (32/32)
- [ ] Eerste monitoring-run na merge zal nieuwe baselines opslaan