### PR TITLE
fix: update NCSC TLS-richtlijnen URL naar v21-tls

### DIFF
--- a/skills/inet-mail/reference.md
+++ b/skills/inet-mail/reference.md
@@ -318,5 +318,5 @@ Verzendende server                    Ontvangende server
 - [Forum Standaardisatie - DKIM](https://www.forumstandaardisatie.nl/open-standaarden/dkim)
 - [Forum Standaardisatie - STARTTLS](https://www.forumstandaardisatie.nl/open-standaarden/starttls-en-dane)
 - [Forum Standaardisatie - DANE](https://www.forumstandaardisatie.nl/open-standaarden/starttls-en-dane)
-- [NCSC - TLS-richtlijnen](https://www.ncsc.nl/en/transport-layer-security-tls/it-security-guidelines-transport-layer-security-tls)
+- [NCSC - TLS-richtlijnen](https://www.ncsc.nl/transport-layer-security-tls/v21-tls)
 - [toolbox-wiki](https://github.com/internetstandards/toolbox-wiki) - Implementatiegidsen

--- a/skills/inet-mail/reference.md
+++ b/skills/inet-mail/reference.md
@@ -318,5 +318,5 @@ Verzendende server                    Ontvangende server
 - [Forum Standaardisatie - DKIM](https://www.forumstandaardisatie.nl/open-standaarden/dkim)
 - [Forum Standaardisatie - STARTTLS](https://www.forumstandaardisatie.nl/open-standaarden/starttls-en-dane)
 - [Forum Standaardisatie - DANE](https://www.forumstandaardisatie.nl/open-standaarden/starttls-en-dane)
-- [NCSC - TLS-richtlijnen](https://www.ncsc.nl/transport-layer-security-tls/v21-tls)
+- [NCSC - TLS Security Guidelines](https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS)
 - [toolbox-wiki](https://github.com/internetstandards/toolbox-wiki) - Implementatiegidsen

--- a/skills/inet-toolbox/reference.md
+++ b/skills/inet-toolbox/reference.md
@@ -324,6 +324,6 @@ done
 - [toolbox-wiki](https://github.com/internetstandards/toolbox-wiki) - Alle implementatiegidsen
 - [internet.nl](https://internet.nl) - Test het resultaat
 - [Forum Standaardisatie](https://www.forumstandaardisatie.nl/open-standaarden) - Standaardenstatus
-- [NCSC - TLS-richtlijnen](https://www.ncsc.nl/en/transport-layer-security-tls/it-security-guidelines-transport-layer-security-tls)
+- [NCSC - TLS-richtlijnen](https://www.ncsc.nl/transport-layer-security-tls/v21-tls)
 - [Mozilla SSL Configuration Generator](https://ssl-config.mozilla.org/)
 - [Let's Encrypt documentatie](https://letsencrypt.org/docs/)

--- a/skills/inet-toolbox/reference.md
+++ b/skills/inet-toolbox/reference.md
@@ -324,6 +324,6 @@ done
 - [toolbox-wiki](https://github.com/internetstandards/toolbox-wiki) - Alle implementatiegidsen
 - [internet.nl](https://internet.nl) - Test het resultaat
 - [Forum Standaardisatie](https://www.forumstandaardisatie.nl/open-standaarden) - Standaardenstatus
-- [NCSC - TLS-richtlijnen](https://www.ncsc.nl/transport-layer-security-tls/v21-tls)
+- [NCSC - TLS Security Guidelines](https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS)
 - [Mozilla SSL Configuration Generator](https://ssl-config.mozilla.org/)
 - [Let's Encrypt documentatie](https://letsencrypt.org/docs/)

--- a/skills/inet-web/SKILL.md
+++ b/skills/inet-web/SKILL.md
@@ -96,7 +96,7 @@ dig example.nl +trace +dnssec | grep -E '(RRSIG|DS|DNSKEY)'
 server. Internet.nl vereist TLS 1.2 of 1.3 met sterke cipher suites.
 
 **Waarom verplicht:** Beschermt vertrouwelijkheid en integriteit van communicatie.
-Zie ook de [NCSC TLS-richtlijnen](https://www.ncsc.nl/en/transport-layer-security-tls/it-security-guidelines-transport-layer-security-tls).
+Zie ook de [NCSC TLS-richtlijnen](https://www.ncsc.nl/transport-layer-security-tls/v21-tls).
 
 **Wat test internet.nl:**
 - HTTPS bereikbaar en redirect van HTTP naar HTTPS

--- a/skills/inet-web/SKILL.md
+++ b/skills/inet-web/SKILL.md
@@ -96,7 +96,7 @@ dig example.nl +trace +dnssec | grep -E '(RRSIG|DS|DNSKEY)'
 server. Internet.nl vereist TLS 1.2 of 1.3 met sterke cipher suites.
 
 **Waarom verplicht:** Beschermt vertrouwelijkheid en integriteit van communicatie.
-Zie ook de [NCSC TLS-richtlijnen](https://www.ncsc.nl/transport-layer-security-tls/v21-tls).
+Zie ook de [NCSC TLS Security Guidelines (2025-05)](https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS).
 
 **Wat test internet.nl:**
 - HTTPS bereikbaar en redirect van HTTP naar HTTPS

--- a/skills/inet-web/reference.md
+++ b/skills/inet-web/reference.md
@@ -37,7 +37,7 @@ Voor TLS 1.3 zijn alleen deze cipher suites beschikbaar (allemaal goed):
 - Geldige keten naar een vertrouwde root CA
 - Hostnaam in Subject Alternative Name (SAN)
 Bronnen:
-- [NCSC - TLS-richtlijnen](https://www.ncsc.nl/en/transport-layer-security-tls/it-security-guidelines-transport-layer-security-tls)
+- [NCSC - TLS-richtlijnen](https://www.ncsc.nl/transport-layer-security-tls/v21-tls)
 - [Forum Standaardisatie - TLS](https://www.forumstandaardisatie.nl/open-standaarden/tls)
 
 ## DNSSEC protocol-details

--- a/skills/inet-web/reference.md
+++ b/skills/inet-web/reference.md
@@ -37,7 +37,7 @@ Voor TLS 1.3 zijn alleen deze cipher suites beschikbaar (allemaal goed):
 - Geldige keten naar een vertrouwde root CA
 - Hostnaam in Subject Alternative Name (SAN)
 Bronnen:
-- [NCSC - TLS-richtlijnen](https://www.ncsc.nl/transport-layer-security-tls/v21-tls)
+- [NCSC - TLS Security Guidelines](https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS)
 - [Forum Standaardisatie - TLS](https://www.forumstandaardisatie.nl/open-standaarden/tls)
 
 ## DNSSEC protocol-details

--- a/tests/fixtures/sample_skill.md
+++ b/tests/fixtures/sample_skill.md
@@ -15,7 +15,7 @@ model: sonnet
 
 - Internet.nl: https://internet.nl/test-site
 - Forum: https://www.forumstandaardisatie.nl/open-standaarden/ipv6-en-dnssec
-- NCSC: https://www.ncsc.nl/transport-layer-security-tls/v21-tls
+- NCSC: https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS
 
 ## Voorbeelden
 

--- a/tests/fixtures/sample_skill.md
+++ b/tests/fixtures/sample_skill.md
@@ -15,7 +15,7 @@ model: sonnet
 
 - Internet.nl: https://internet.nl/test-site
 - Forum: https://www.forumstandaardisatie.nl/open-standaarden/ipv6-en-dnssec
-- NCSC: https://www.ncsc.nl/en/transport-layer-security-tls/it-security-guidelines-transport-layer-security-tls
+- NCSC: https://www.ncsc.nl/transport-layer-security-tls/v21-tls
 
 ## Voorbeelden
 


### PR DESCRIPTION
## Samenvatting

De Engelse NCSC URL (`/en/transport-layer-security-tls/it-security-guidelines-transport-layer-security-tls`) geeft sinds de NCSC site-migratie een 404. Er is geen Engelse vervanging beschikbaar; de Nederlandse `v21-tls` pagina is de canonieke bron.

## Wijzigingen

- `skills/inet-web/SKILL.md`
- `skills/inet-web/reference.md`
- `skills/inet-mail/reference.md`
- `skills/inet-toolbox/reference.md`
- `tests/fixtures/sample_skill.md`

Alle NCSC TLS-richtlijnen links wijzen nu naar `https://www.ncsc.nl/transport-layer-security-tls/v21-tls` (HTTP 200).

Fixes #152.