### PR TITLE
docs: documenteer TLS-wijzigingen Internet.nl v1.11.0

### DIFF
--- a/skills/inet-api/reference.md
+++ b/skills/inet-api/reference.md
@@ -378,8 +378,23 @@ class InternetNLClient:
         logger.info("Resultaten opgeslagen in %s", output_path)
 ```
 
+## TLS-velddetails sinds v1.11.0 (API v2.7.0)
+
+De v1.11.0 release (NCSC TLS-richtlijnen 2025-05) wijzigt enkele TLS-velden in de batch-resultaten:
+
+| Veld | Wijziging |
+|------|-----------|
+| `web_tls_clientreneg` / `mail_tls_clientreneg` | Status was boolean, is nu een enum: `not_allowed` (good), `allowed_with_low_limit` (info, < 10 renegotiations), `allowed_with_too_high_limit` (failed) |
+| `web_tls_ocsp` / `mail_tls_ocsp` | Nieuwe status `not_in_cert` (not_tested) wanneer het certificaat geen OCSP-endpoint bevat; stapling is dan technisch onmogelijk en wordt niet als fout gerekend |
+| `web_tls_extended_master_secret` / `mail_tls_extended_master_secret` | Nieuw veld (RFC 7627). Statussen: `supported` (good), `not_supported` (failed), `na_no_tls_1_2` (good, alleen TLS 1.3 onderhandeld), `unknown` (not_tested) |
+| `web_tls_cipher_order` | Status `not_prescribed` en `not_seclevel` zijn vervallen; verkeerde voorkeur of geen voorkeur is nu allebei `bad` |
+| `cert_signature_phase_out` | Nieuw veld in TLS-details, naast bestaande `cert_signature_bad`. Lijst met certificaat-signature-algoritmes op phase-out niveau (warning) |
+
+Een client die `clientreneg` als boolean parseert, breekt op v2.7.0. Pas de parser aan op string-enum.
+
 ## Bronnen
 
 - [Internet.nl-API-docs](https://github.com/internetstandards/Internet.nl-API-docs) - Officieel API-documentatie
 - [Internet.nl](https://github.com/internetstandards/Internet.nl) - Testsuite broncode
 - [internet.nl](https://internet.nl) - Website en API-registratie
+- [Internet.nl v1.11.0 release notes](https://github.com/internetstandards/Internet.nl/releases/tag/v1.11.0)

--- a/skills/inet-web/reference.md
+++ b/skills/inet-web/reference.md
@@ -36,6 +36,16 @@ Voor TLS 1.3 zijn alleen deze cipher suites beschikbaar (allemaal goed):
 - SHA-256 of hoger als hash-algoritme
 - Geldige keten naar een vertrouwde root CA
 - Hostnaam in Subject Alternative Name (SAN)
+
+### Renegotiation en OCSP (NCSC 2025-05)
+
+Met de NCSC TLS-richtlijnen van mei 2025 (geïmplementeerd in Internet.nl v1.11.0):
+
+- **Client-initiated renegotiation** is acceptabel mits de server het aantal renegotiations beperkt tot minder dan 10 per verbinding. Onbeperkte client renegotiation blijft een fout (DoS-risico).
+- **Secure renegotiation** (RFC 5746) blijft verplicht.
+- **Extended Master Secret** (RFC 7627) is een aparte test geworden voor TLS 1.2; ontbreken telt als fout. Voor TLS 1.3 niet van toepassing.
+- **OCSP stapling** wordt niet langer als fout gerekend wanneer het certificaat zelf geen OCSP-endpoint bevat (`AIA` zonder OCSP URI). In dat geval is stapling technisch onmogelijk en wordt het als niet-getest gemeld.
+
 Bronnen:
 - [NCSC - TLS Security Guidelines](https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS)
 - [Forum Standaardisatie - TLS](https://www.forumstandaardisatie.nl/open-standaarden/tls)


### PR DESCRIPTION
## Samenvatting

Internet.nl v1.11.0 (release 2026-04-22) implementeert de NCSC TLS-richtlijnen van mei 2025. Deze PR documenteert de relevante wijzigingen in de twee skills die TLS-detail behandelen.

### inet-web/reference.md
Nieuwe sectie *Renegotiation en OCSP (NCSC 2025-05)*:
- Client-initiated renegotiation acceptabel mits < 10 per verbinding
- Secure renegotiation (RFC 5746) blijft verplicht
- Extended Master Secret (RFC 7627) is aparte test voor TLS 1.2
- OCSP stapling rapporteert `not_in_cert` als cert geen OCSP-endpoint heeft

### inet-api/reference.md
Nieuwe sectie *TLS-velddetails sinds v1.11.0 (API v2.7.0)* met tabel:
- `clientreneg` boolean → enum (`not_allowed`, `allowed_with_low_limit`, `allowed_with_too_high_limit`)
- `ocsp` nieuwe status `not_in_cert`
- `extended_master_secret` nieuw veld met 4 statussen
- `cipher_order` vereenvoudigd: `not_prescribed`/`not_seclevel` vervallen
- `cert_signature_phase_out` nieuw veld

Plus expliciete waarschuwing dat clients die `clientreneg` als boolean parseren breken op v2.7.0.

## Test plan

- [x] `uv run pytest` groen (52 tests)
- [x] `ruff check` groen
- [x] Geen em-dashes
- [ ] CI checks groen na merge-ready