### PR TITLE
fix: kort skill descriptions in om listing budget te ontlasten

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Achtergrondkennis die niet direct nodig is voor configuratie-generatie wordt ver
 - Exploratie commando's (`dig`, `openssl`, `gh api`)
 
 ### Description triggers
-Descriptions bevatten zowel Nederlandse als technische Engelse triggerwoorden zodat de skill bij relevante vragen wordt geactiveerd.
+Descriptions bevatten zowel Nederlandse als technische Engelse triggerwoorden zodat de skill bij relevante vragen wordt geactiveerd. Houd descriptions kort: doel **~150 chars, max 200**. Eén functionele zin met de eigennamen die mensen daadwerkelijk gebruiken (DMARC, DNSSEC, security.txt) is genoeg; voeg alleen een korte triggerstaart toe voor termen die niet uit de hoofdzin volgen. Geen "Triggers:"-staarten die de hoofdzin dupliceren — die vreten skill listing budget op zonder triggerwaarde toe te voegen.
 
 ### Allowed tools
 Standaard set:

--- a/skills/inet-api/SKILL.md
+++ b/skills/inet-api/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: inet-api
-description: >-
-  Internet.nl batch API voor het geautomatiseerd testen van meerdere
-  domeinen op internetstandaarden. Authenticatie, batch requests,
-  polling, resultaten JSON, dashboard-integratie.
-  Triggers: internet.nl API, batch API, bulk scan, compliance dashboard,
-  internet.nl batch, API credentials, geautomatiseerd testen,
-  domeinenscan, monitoring dashboard
+description: "Internet.nl batch API voor geautomatiseerd testen van meerdere domeinen: authenticatie, polling, JSON-resultaten, dashboard-integratie, bulk scans."
 model: sonnet
 allowed-tools:
   - Bash(gh api *)

--- a/skills/inet-mail/SKILL.md
+++ b/skills/inet-mail/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: inet-mail
-description: >-
-  Mailstandaarden getest door internet.nl: SPF (Sender Policy Framework),
-  DKIM (DomainKeys Identified Mail), DMARC (Domain-based Message Authentication),
-  STARTTLS, DANE (DNS-based Authentication of Named Entities).
-  Triggers: mail test, DMARC, DKIM, SPF, STARTTLS, DANE,
-  mailserver beveiliging, email security, e-mailbeveiliging,
-  mailstandaarden, anti-spoofing
+description: "Mailstandaarden van internet.nl: SPF, DKIM, DMARC, STARTTLS, DANE. Anti-spoofing, mailserver-beveiliging, e-mailbeveiliging."
 model: sonnet
 allowed-tools:
   - Bash(gh api *)

--- a/skills/inet-toolbox/SKILL.md
+++ b/skills/inet-toolbox/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: inet-toolbox
-description: >-
-  Stap-voor-stap implementatiegidsen uit de internet.nl toolbox-wiki.
-  Configuratie van DNSSEC, HTTPS/TLS, DMARC, DKIM, SPF, DANE en IPv6
-  op veelgebruikte platformen (BIND, NSD, Nginx, Apache, Postfix).
-  Triggers: internet.nl toolbox, DMARC configuratie, DKIM instellen,
-  SPF record, DANE opzetten, implementatiegids, DNSSEC instellen,
-  Let's Encrypt, certificaat, mailserver configureren
+description: "Implementatiegidsen uit de internet.nl toolbox-wiki: DNSSEC, HTTPS/TLS, DMARC, DKIM, SPF, DANE, IPv6 op BIND, NSD, Nginx, Apache, Postfix. Let's Encrypt."
 model: sonnet
 allowed-tools:
   - Bash(gh api *)

--- a/skills/inet-web/SKILL.md
+++ b/skills/inet-web/SKILL.md
@@ -1,13 +1,6 @@
 ---
 name: inet-web
-description: >-
-  Webstandaarden getest door internet.nl: HTTPS, TLS 1.2/1.3, HSTS,
-  DNSSEC voor websites, IPv6 dual-stack, RPKI route origin validation,
-  security headers (CSP, X-Frame-Options, X-Content-Type-Options,
-  Referrer-Policy), security.txt (RFC 9116).
-  Triggers: web test, HTTPS, TLS, HSTS, DNSSEC website,
-  security headers, security.txt, IPv6, RPKI, webstandaarden,
-  website testen, Content-Security-Policy
+description: "Webstandaarden van internet.nl: HTTPS, TLS 1.2/1.3, HSTS, DNSSEC, IPv6 dual-stack, RPKI, security headers (CSP), security.txt (RFC 9116)."
 model: sonnet
 allowed-tools:
   - Bash(gh api *)

--- a/skills/inet/SKILL.md
+++ b/skills/inet/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: inet
-description: >-
-  Overzicht van alle internetstandaarden die internet.nl test.
-  Routing naar sub-skills voor web, mail, API en toolbox.
-  Triggers: internet.nl, internet standaarden, website compliance,
-  mail compliance, internetstandaarden, open standaarden,
-  Forum Standaardisatie, pas-toe-of-leg-uit
+description: "Internetstandaarden getest door internet.nl. Routeert naar sub-skills voor web, mail, API en toolbox. Forum Standaardisatie pas-toe-of-leg-uit."
 model: sonnet
 allowed-tools:
   - Bash(gh api *)


### PR DESCRIPTION
## Probleem

Per `developer-overheid-nl/skills-marketplace#61` melden gebruikers dat onze plugin descriptions zoveel skill listing budget vreten dat in gemengde sessies skills uit de listing vallen ("60 descriptions dropped, 3.1%/1% of context").

Onze 5 internet-skills gingen tot 395 chars (`inet-web`), gemiddeld 351 chars. Het patroon hier was functionele zin + uitgeschreven afkortingen ("SPF (Sender Policy Framework)") + lange "Triggers:"-staart die de hoofdzin dupliceerde.

## Wat verandert

Per skill: één Nederlandse functionele zin met de eigennamen die mensen gebruiken. Uitgeschreven afkortingen geschrapt (het model kent SPF/DKIM/DMARC al). Triggers-staart geschrapt waar die de hoofdzin dupliceerde. Doel ~150 chars, max 200.

Niet-afleidbare jargon blijft expliciet:
- `inet-mail`: SPF, DKIM, DMARC, STARTTLS, DANE
- `inet-web`: HSTS, RPKI, security.txt (RFC 9116)
- `inet-toolbox`: BIND, NSD, Nginx, Apache, Postfix, Let's Encrypt
- `inet-api`: batch API, polling, JSON-resultaten

## Resultaat

| Skill | Was | Nu |
|---|---:|---:|
| `inet` | 279 | 143 |
| `inet-api` | 344 | 147 |
| `inet-mail` | 357 | 124 |
| `inet-toolbox` | 382 | 153 |
| `inet-web` | 395 | 137 |
| **Totaal** | **1 757** | **704** |

Reductie: -60%.

`CLAUDE.md` bijgewerkt met expliciete lengte-richtlijn voor toekomstige skills.

## Test plan

- [x] `uv run pytest -q` — 52 passed
- [x] `uvx ruff check / format --check` — schoon
- [ ] Verificatievragen uit `CLAUDE.md` triggeren nog steeds de juiste skills (handmatig na merge)

Refs developer-overheid-nl/skills-marketplace#61