### PR TITLE
chore: audit-rapporten per skill

### DIFF
--- a/skills/inet-api/audit.md
+++ b/skills/inet-api/audit.md
@@ -7,46 +7,46 @@
 
 | Status | Aantal | % |
 |--------|--------|---|
-| UNSUPPORTED_ASSERTION | 34 | 83% |
+| UNSUPPORTED_ASSERTION | 31 | 69% |
 | CONTRADICTED | 0 | 0% |
-| PARTIALLY_GROUNDED | 1 | 2% |
-| UNGROUNDED | 6 | 15% |
+| PARTIALLY_GROUNDED | 8 | 18% |
+| UNGROUNDED | 6 | 13% |
 | NO_SOURCE | 0 | 0% |
 | UNVERIFIABLE | 0 | 0% |
 | KNOWN_DISCREPANCY | 0 | 0% |
 | GROUNDED | 0 | 0% |
 
-*Geverifieerd met sonnet, 2 calls, $0.1587.*
+*Geverifieerd met sonnet, 2 calls, $0.1735.*
 
-## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (34)
+## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (31)
 
 ### `inet-api-0002` — SKILL.md:45 *(§ Toegang verkrijgen)*
 
-> Authenticatie bij de internet.nl batch API gaat via HTTP Basic Auth.
+> Authenticatie voor de batch API gaat via HTTP Basic Auth.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API authenticatie
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - authenticatie
 
 - **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
   - *Bron status: unreachable*
 - **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
-  - *De aangeleverde brontekst is de GitHub README en bevat geen informatie over API-authenticatie.*
+  - *De README noemt de batch API niet en geeft geen informatie over authenticatiemechanismen.*
 
 ### `inet-api-0003` — SKILL.md:52 *(§ API-workflow)*
 
-> De batch API werkt met een poll-model: batch indienen (POST) geeft een request-ID, daarna pollen op status tot 'done', dan resultaten ophalen.
+> De batch API werkt met een poll-model: batch indienen (POST) geeft een request-ID, daarna polling (GET) tot status 'done', dan resultaten ophalen als JSON.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API workflow
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - workflow
 
 - **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
   - *Bron status: unreachable*
 - **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
-  - *Geen informatie over batch API workflow in de aangeleverde brontekst.*
+  - *Geen informatie over de batch API workflow in de aangeleverde brontekst.*
 
 ### `inet-api-0004` — SKILL.md:64 *(§ API-endpoints)*
 
-> Batch indienen (web of mail) gaat via POST naar /api/batch/v2/requests.
+> Batch indienen (web of mail) gebruikt POST op endpoint `/api/batch/v2/requests`.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API endpoints
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - endpoints
 
 - **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
   - *Bron status: unreachable*
@@ -54,9 +54,9 @@
 
 ### `inet-api-0005` — SKILL.md:65 *(§ API-endpoints)*
 
-> Overzicht van eigen requests is opvraagbaar via GET /api/batch/v2/requests.
+> Overzicht van eigen requests opvragen gebruikt GET op `/api/batch/v2/requests`.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API endpoints
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - endpoints
 
 - **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
   - *Bron status: unreachable*
@@ -64,9 +64,9 @@
 
 ### `inet-api-0006` — SKILL.md:66 *(§ API-endpoints)*
 
-> Batchstatus opvragen gaat via GET /api/batch/v2/requests/{request_id}.
+> Status opvragen gebruikt GET op `/api/batch/v2/requests/{request_id}`.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API endpoints
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - endpoints
 
 - **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
   - *Bron status: unreachable*
@@ -74,9 +74,9 @@
 
 ### `inet-api-0007` — SKILL.md:67 *(§ API-endpoints)*
 
-> Een batch annuleren gaat via PATCH /api/batch/v2/requests/{request_id}.
+> Batch annuleren gebruikt PATCH op `/api/batch/v2/requests/{request_id}`.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API endpoints
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - endpoints
 
 - **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
   - *Bron status: unreachable*
@@ -84,9 +84,9 @@
 
 ### `inet-api-0008` — SKILL.md:68 *(§ API-endpoints)*
 
-> Resultaten ophalen gaat via GET /api/batch/v2/requests/{request_id}/results.
+> Resultaten ophalen gebruikt GET op `/api/batch/v2/requests/{request_id}/results`.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API endpoints
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - endpoints
 
 - **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
   - *Bron status: unreachable*
@@ -94,9 +94,9 @@
 
 ### `inet-api-0009` — SKILL.md:69 *(§ API-endpoints)*
 
-> Technische resultaten zijn opvraagbaar via GET /api/batch/v2/requests/{request_id}/results_technical.
+> Technische resultaten ophalen gebruikt GET op `/api/batch/v2/requests/{request_id}/results_technical`.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API endpoints
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - endpoints
 
 - **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
   - *Bron status: unreachable*
@@ -104,9 +104,9 @@
 
 ### `inet-api-0010` — SKILL.md:70 *(§ API-endpoints)*
 
-> Rapportage-metadata is opvraagbaar via GET /api/batch/v2/metadata/report.
+> Rapportage-metadata ophalen gebruikt GET op `/api/batch/v2/metadata/report`.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API endpoints
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - endpoints
 
 - **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
   - *Bron status: unreachable*
@@ -114,9 +114,19 @@
 
 ### `inet-api-0011` — SKILL.md:72 *(§ API-endpoints)*
 
-> De base URL van de internet.nl batch API is https://batch.internet.nl.
+> De base URL van de batch API is `https://batch.internet.nl`.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API endpoints
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - endpoints
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0012` — SKILL.md:74 *(§ API-endpoints)*
+
+> Het testtype (`"web"` of `"mail"`) wordt meegegeven in de request body, niet in het URL-pad.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - request-formaat
 
 - **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
   - *Bron status: unreachable*
@@ -124,179 +134,150 @@
 
 ### `inet-api-0013` — SKILL.md:75 *(§ API-endpoints)*
 
-> Het request_id is een 32-karakter hexadecimale string.
+> Het `request_id` is een 32-karakter hexadecimale string.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API request_id formaat
-
-- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
-  - *Bron status: unreachable*
-- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
-
-### `inet-api-0014` — SKILL.md:99 *(§ Batch indienen)*
-
-> Een batch submit response bevat de velden request_id, request_type en status ('registering').
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API response-formaat
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - request_id formaat
 
 - **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
   - *Bron status: unreachable*
 - **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
 
-### `inet-api-0015` — SKILL.md:139 *(§ Status opvragen en resultaten ophalen)*
+### `inet-api-0014` — SKILL.md:139 *(§ Status opvragen en resultaten ophalen)*
 
-> Mogelijke batchstatussen zijn: registering, running, generating, done, error, cancelled.
+> De mogelijke batch-statussen zijn: `registering`, `running`, `generating`, `done`, `error`, `cancelled`.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API statuswaarden
-
-- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
-  - *Bron status: unreachable*
-- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
-
-### `inet-api-0016` — SKILL.md:321 *(§ Categorieen (webtest))*
-
-> De categorie 'appsecpriv' (webtest) omvat security headers en security.txt.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API webtest categorieën
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - statuswaarden
 
 - **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
   - *Bron status: unreachable*
 - **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
 
-### `inet-api-0017` — SKILL.md:318 *(§ Categorieen (webtest))*
+### `inet-api-0017` — SKILL.md:307 *(§ Verdicts)*
 
-> De webtest categorieën zijn: ipv6, dnssec, tls, appsecpriv en rpki.
+> De mogelijke verdict-waarden per test zijn: `passed`, `warning`, `failed`, `info`, `not_tested`.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API webtest categorieën
-
-- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
-  - *Bron status: unreachable*
-- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
-
-### `inet-api-0018` — SKILL.md:327 *(§ Categorieen (mailtest))*
-
-> De mailtest categorieën zijn: ipv6, dnssec, auth (SPF, DKIM, DMARC), tls (STARTTLS, DANE, certificaat) en rpki.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API mailtest categorieën
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - verdict-waarden
 
 - **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
   - *Bron status: unreachable*
 - **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
 
-### `inet-api-0019` — SKILL.md:393 *(§ Veelvoorkomende problemen)*
+### `inet-api-0019` — SKILL.md:390 *(§ Veelvoorkomende problemen)*
 
-> Bij grote batches (te veel domeinen tegelijk) kan een timeout optreden; de oplossing is splitsen in kleinere batches van maximaal 5.000 domeinen per batch.
+> HTTP 429 treedt op als het rate limit bereikt is.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API beperkingen
-
-- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
-  - *Bron status: unreachable*
-- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
-
-### `inet-api-0020` — SKILL.md:390 *(§ Veelvoorkomende problemen)*
-
-> HTTP 429 bij de batch API betekent dat de rate limit bereikt is.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API foutcodes
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - foutcodes
 
 - **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
   - *Bron status: unreachable*
 - **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
 
-### `inet-api-0021` — reference.md:8 *(§ API-versie)*
+### `inet-api-0020` — reference.md:8 *(§ API-versie)*
 
-> De huidige versie van de internet.nl batch API is v2.
+> De huidige versie van de batch API is v2.
 
-**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API versie
-
-- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
-  - *Bron status: unreachable*
-- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
-
-### `inet-api-0022` — reference.md:23 *(§ Authenticatie)*
-
-> De API gebruikt HTTP Basic Authentication via de Authorization-header: Basic base64(gebruikersnaam:wachtwoord).
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API authenticatie
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - versie
 
 - **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
   - *Bron status: unreachable*
 - **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
 
-### `inet-api-0025` — reference.md:58 *(§ Batch indienen)*
+### `inet-api-0021` — reference.md:23 *(§ Authenticatie)*
 
-> Het veld 'name' in de batch request body is niet verplicht, heeft een maximum van 255 tekens en is bedoeld voor eigen administratie.
+> De API gebruikt HTTP Basic Authentication met het formaat `Authorization: Basic base64(gebruikersnaam:wachtwoord)`.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API request-formaat
-
-- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
-  - *Bron status: unreachable*
-- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
-
-### `inet-api-0028` — reference.md:68 *(§ Beperkingen)*
-
-> Verwerking per gebruiker is sequentieel (FIFO), met 1 actieve batch tegelijk.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API beperkingen
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - authenticatie
 
 - **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
   - *Bron status: unreachable*
 - **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
 
-### `inet-api-0029` — reference.md:70 *(§ Beperkingen)*
+### `inet-api-0022` — reference.md:58 *(§ Batch indienen)*
 
-> De beperkingen (max domeinen, max requests per week, FIFO) zijn vastgelegd in de Terms of Use op GitHub.
+> Het veld `name` in de batch request body is niet verplicht, maximaal 255 tekens, en dient voor eigen administratie.
 
-**Type:** reference_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API beperkingen
-
-- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
-  - *Bron status: unreachable*
-- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
-
-### `inet-api-0030` — reference.md:263 *(§ Foutcodes)*
-
-> HTTP 400 bij de batch API betekent een ongeldige request; de actie is het controleren van het JSON-formaat en verplichte velden.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API foutcodes
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - request-formaat
 
 - **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
   - *Bron status: unreachable*
 - **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
 
-### `inet-api-0031` — reference.md:264 *(§ Foutcodes)*
+### `inet-api-0027` — reference.md:68 *(§ Beperkingen)*
 
-> HTTP 401 bij de batch API betekent niet geautoriseerd; de actie is het controleren van credentials.
+> Verwerking per gebruiker is sequentieel (FIFO, 1 actieve batch tegelijk).
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API foutcodes
-
-- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
-  - *Bron status: unreachable*
-- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
-
-### `inet-api-0032` — reference.md:266 *(§ Foutcodes)*
-
-> HTTP 404 bij de batch API betekent dat de batch niet gevonden is; de actie is het controleren van het request-ID.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API foutcodes
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - beperkingen
 
 - **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
   - *Bron status: unreachable*
 - **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
 
-### `inet-api-0033` — reference.md:267 *(§ Foutcodes)*
+### `inet-api-0028` — reference.md:70 *(§ Beperkingen)*
 
-> HTTP 429 bij de batch API betekent dat de rate limit bereikt is.
+> De beperkingen (max domeinen, max requests per week, sequentiële verwerking) zijn gedocumenteerd in de Terms of Use op GitHub.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API foutcodes
+**Type:** reference_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - beperkingen
 
 - **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
   - *Bron status: unreachable*
 - **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0029` — reference.md:263 *(§ Foutcodes)*
+
+> HTTP 400 treedt op bij een ongeldige request; de client moet het JSON-formaat en verplichte velden controleren.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - foutcodes
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0030` — reference.md:264 *(§ Foutcodes)*
+
+> HTTP 401 treedt op bij ongeldige credentials.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - foutcodes
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0031` — reference.md:266 *(§ Foutcodes)*
+
+> HTTP 404 treedt op als de batch niet gevonden wordt; het request-ID moet gecontroleerd worden.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - foutcodes
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0032` — reference.md:267 *(§ Foutcodes)*
+
+> HTTP 429 treedt op als het rate limit bereikt is.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - foutcodes
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0033` — reference.md:381 *(§ TLS-velddetails sinds v1.11.0 (API v2.7.0))*
+
+> De v1.11.0 release implementeert NCSC TLS-richtlijnen 2025-05 en wijzigt enkele TLS-velden in de batch-resultaten (API v2.7.0).
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - TLS-veldwijzigingen v1.11.0
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+  - *De Changelog.md wordt vermeld in de bestandslijst maar de inhoud ervan is niet aangeleverd in de brontekst.*
 
 ### `inet-api-0034` — reference.md:387 *(§ TLS-velddetails sinds v1.11.0 (API v2.7.0))*
 
-> Vanaf v1.11.0 (API v2.7.0) is het veld 'clientreneg' gewijzigd van boolean naar een string-enum: 'not_allowed' (good), 'allowed_with_low_limit' (info), 'allowed_with_too_high_limit' (failed).
+> Vanaf API v2.7.0 is `web_tls_clientreneg`/`mail_tls_clientreneg` geen boolean meer maar een enum: `not_allowed` (good), `allowed_with_low_limit` (info, < 10 renegotiations), `allowed_with_too_high_limit` (failed).
 
-**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API TLS-velden v1.11.0
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - TLS-veldwijzigingen v2.7.0
 
 - **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
   - *Bron status: unreachable*
@@ -304,9 +285,9 @@
 
 ### `inet-api-0035` — reference.md:388 *(§ TLS-velddetails sinds v1.11.0 (API v2.7.0))*
 
-> Vanaf v1.11.0 (API v2.7.0) heeft het veld 'web_tls_ocsp'/'mail_tls_ocsp' een nieuwe statuswaarde 'not_in_cert' (not_tested) wanneer het certificaat geen OCSP-endpoint bevat; dit wordt niet als fout gerekend.
+> Vanaf API v2.7.0 heeft `web_tls_ocsp`/`mail_tls_ocsp` een nieuwe status `not_in_cert` (not_tested) wanneer het certificaat geen OCSP-endpoint bevat; dit wordt niet als fout gerekend.
 
-**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API TLS-velden v1.11.0
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - TLS-veldwijzigingen v2.7.0
 
 - **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
   - *Bron status: unreachable*
@@ -314,18 +295,18 @@
 
 ### `inet-api-0036` — reference.md:389 *(§ TLS-velddetails sinds v1.11.0 (API v2.7.0))*
 
-> Vanaf v1.11.0 (API v2.7.0) is het nieuwe veld 'web_tls_extended_master_secret'/'mail_tls_extended_master_secret' toegevoegd (RFC 7627) met statussen: 'supported' (good), 'not_supported' (failed), 'na_no_tls_1_2' (good), 'unknown' (not_tested).
+> Vanaf API v2.7.0 is `web_tls_extended_master_secret`/`mail_tls_extended_master_secret` een nieuw veld (RFC 7627) met statussen: `supported` (good), `not_supported` (failed), `na_no_tls_1_2` (good), `unknown` (not_tested).
 
-**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API TLS-velden v1.11.0
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - TLS-veldwijzigingen v2.7.0
 
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7627.txt](https://www.rfc-editor.org/rfc/rfc7627.txt)
-  - *De bron is RFC 7627 zelf (de technische specificatie van de TLS Extended Master Secret extension). De claim gaat over de Internet.nl batch API v1.11.0/v2.7.0 en de specifieke veldnamen, statussen en versienummering in die API. Dat is implementatie-specifieke API-documentatie die niet in deze RFC staat.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7627.txt](https://www.rfc-editor.org/rfc/rfc7627.txt)
+  - *De bron is RFC 7627 zelf (de technische specificatie van de Extended Master Secret extensie). De claim gaat over de Internet.nl batch API v2.7.0 en de specifieke veldnamen, statussen en versie-introductie daarvan. Die API-documentatie staat niet in deze RFC.*
 
 ### `inet-api-0037` — reference.md:390 *(§ TLS-velddetails sinds v1.11.0 (API v2.7.0))*
 
-> Vanaf v1.11.0 (API v2.7.0) zijn de statussen 'not_prescribed' en 'not_seclevel' voor 'web_tls_cipher_order' vervallen; verkeerde voorkeur of geen voorkeur is nu allebei 'bad'.
+> Vanaf API v2.7.0 zijn de statussen `not_prescribed` en `not_seclevel` voor `web_tls_cipher_order` vervallen; verkeerde voorkeur of geen voorkeur is nu allebei `bad`.
 
-**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API TLS-velden v1.11.0
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - TLS-veldwijzigingen v2.7.0
 
 - **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
   - *Bron status: unreachable*
@@ -333,56 +314,128 @@
 
 ### `inet-api-0038` — reference.md:391 *(§ TLS-velddetails sinds v1.11.0 (API v2.7.0))*
 
-> Vanaf v1.11.0 (API v2.7.0) is het nieuwe veld 'cert_signature_phase_out' toegevoegd in TLS-details, naast 'cert_signature_bad', met een lijst van certificaat-signature-algoritmes op phase-out niveau (warning).
+> Vanaf API v2.7.0 is `cert_signature_phase_out` een nieuw veld in TLS-details, naast het bestaande `cert_signature_bad`, met een lijst van certificaat-signature-algoritmes op phase-out niveau (warning).
 
-**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API TLS-velden v1.11.0
-
-- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
-  - *Bron status: unreachable*
-- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
-
-### `inet-api-0040` — SKILL.md:308 *(§ Verdicts)*
-
-> De verdict-waarden in batch resultaten zijn: 'passed', 'warning', 'failed', 'info', 'not_tested'.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API resultatenstructuur
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - TLS-veldwijzigingen v2.7.0
 
 - **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
   - *Bron status: unreachable*
 - **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
 
-### `inet-api-0041` — reference.md:383 *(§ TLS-velddetails sinds v1.11.0 (API v2.7.0))*
+### `inet-api-0045` — reference.md:389 *(§ TLS-velddetails sinds v1.11.0 (API v2.7.0))*
 
-> De v1.11.0 release is gebaseerd op NCSC TLS-richtlijnen 2025-05.
+> Het `extended_master_secret`-veld (RFC 7627) is nieuw in API v2.7.0.
 
-**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API versie v1.11.0
+**Type:** reference_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - TLS-veldwijzigingen v2.7.0
 
-- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
-  - *Bron status: unreachable*
-- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
-  - *De aangeleverde brontekst vermeldt wel release 1.11.0 als 'Latest Apr 21, 2026' in de releases-lijst, maar bevat geen inhoudelijke informatie over NCSC TLS-richtlijnen 2025-05 als basis voor die release.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7627.txt](https://www.rfc-editor.org/rfc/rfc7627.txt)
+  - *De bron is RFC 7627, een IETF-standaard. De claim over wanneer het veld nieuw werd geïntroduceerd in de Internet.nl batch API (v2.7.0) valt buiten het bereik van deze RFC.*
 
-## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (1)
+## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (8)
 
 ### `inet-api-0001` — SKILL.md:25 *(§ Overzicht)*
 
 > De internet.nl batch API maakt het mogelijk om meerdere domeinen tegelijk te testen op internetstandaarden.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API algemeen
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - algemeen
 
 - **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
   - *Bron status: unreachable*
 - **PARTIALLY_SUPPORTED** (medium) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
   > Internet.nl is an initiative of the Dutch Internet Standards Platform that helps you to check whether your website, email and internet connection use modern and reliable Internet Standards.
-  - *De bron bevestigt dat Internet.nl domeinen test op internetstandaarden, maar de batch API als specifieke functionaliteit wordt niet vermeld in de aangeleverde README-tekst.*
+  - *De bron bevestigt dat Internet.nl domeinen test op internetstandaarden, maar de batch API (meerdere domeinen tegelijk) wordt in deze README niet expliciet beschreven.*
+
+### `inet-api-0015` — SKILL.md:317 *(§ Categorieen (webtest))*
+
+> De webtest-resultaten bevatten per domein categorieën: `ipv6`, `dnssec`, `tls`, `appsecpriv`, `rpki`.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - webtest categorieën
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **PARTIALLY_SUPPORTED** (low) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+  > Currently the following modern internet standards are considered within scope: IPv6 (modern address), DNSSEC (signed domain), HTTPS (secure website connection), website security options (such as security headers), STARTTLS and DANE (secure mail server connection), DMARC+DKIM+SPF (anti-spoofing), and RPKI (secure routing).
+  - *De bron noemt IPv6, DNSSEC, HTTPS/TLS, security headers en RPKI als testgebieden, wat de categorieën ipv6, dnssec, tls, appsecpriv en rpki deels ondersteunt. Maar de koppeling aan specifieke batch API-categorienamen staat niet in de bron.*
+
+### `inet-api-0016` — SKILL.md:327 *(§ Categorieen (mailtest))*
+
+> De mailtest-resultaten bevatten per domein categorieën: `ipv6`, `dnssec`, `auth`, `tls`, `rpki`.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - mailtest categorieën
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **PARTIALLY_SUPPORTED** (low) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+  > Currently the following modern internet standards are considered within scope: IPv6 (modern address), DNSSEC (signed domain), STARTTLS and DANE (secure mail server connection), DMARC+DKIM+SPF (anti-spoofing), and RPKI (secure routing).
+  - *De bron noemt de standaarden die overeenkomen met de mailtest-categorieën ipv6, dnssec, auth (SPF/DKIM/DMARC), tls en rpki, maar koppelt ze niet expliciet aan batch API-categorienamen.*
+
+### `inet-api-0040` — SKILL.md:319 *(§ Categorieen (webtest))*
+
+> De webtest categorie `ipv6` test IPv6-bereikbaarheid (AAAA-records, nameservers).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - webtest categorieën
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **PARTIALLY_SUPPORTED** (low) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+  > Currently the following modern internet standards are considered within scope: IPv6 (modern address), DNSSEC (signed domain)...
+  - *De bron noemt IPv6 als testgebied maar vermeldt AAAA-records of nameservers niet expliciet. De koppeling aan de batch API categorie ipv6 staat niet in de bron.*
+
+### `inet-api-0041` — SKILL.md:322 *(§ Categorieen (webtest))*
+
+> De webtest categorie `appsecpriv` test security headers en security.txt.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - webtest categorieën
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **PARTIALLY_SUPPORTED** (low) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+  > Currently the following modern internet standards are considered within scope: ... HTTPS (secure website connection), website security options (such as security headers)...
+  - *Security headers worden als testgebied bevestigd, maar security.txt en de specifieke categorienaam appsecpriv staan niet in de bron.*
+
+### `inet-api-0042` — SKILL.md:331 *(§ Categorieen (mailtest))*
+
+> De mailtest categorie `auth` test SPF, DKIM en DMARC.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - mailtest categorieën
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **PARTIALLY_SUPPORTED** (low) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+  > Currently the following modern internet standards are considered within scope: ... DMARC+DKIM+SPF (anti-spoofing)...
+  - *SPF, DKIM en DMARC worden bevestigd als testgebied. De koppeling aan de batch API categorienaam auth staat niet in de bron.*
+
+### `inet-api-0043` — SKILL.md:332 *(§ Categorieen (mailtest))*
+
+> De mailtest categorie `tls` test STARTTLS, DANE en het certificaat.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - mailtest categorieën
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **PARTIALLY_SUPPORTED** (low) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+  > Currently the following modern internet standards are considered within scope: ... STARTTLS and DANE (secure mail server connection)...
+  - *STARTTLS en DANE worden bevestigd. Het certificaat als onderdeel van de tls-categorie staat niet expliciet in de bron. De categorienaam tls staat niet in de bron.*
+
+### `inet-api-0044` — SKILL.md:323 *(§ Categorieen (webtest))*
+
+> De webtest categorie `rpki` test RPKI Route Origin Validation.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API - webtest categorieën
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **PARTIALLY_SUPPORTED** (low) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+  > Currently the following modern internet standards are considered within scope: ... RPKI (secure routing).
+  - *RPKI wordt bevestigd als testgebied. Route Origin Validation als specifieke term en de koppeling aan de batch API categorienaam rpki staan niet in de bron.*
 
 ## UNGROUNDED — geen bron ondersteunt de claim (6)
 
-### `inet-api-0012` — SKILL.md:74 *(§ API-endpoints)*
+### `inet-api-0018` — SKILL.md:393 *(§ Veelvoorkomende problemen)*
 
-> Het testtype ('web' of 'mail') wordt meegegeven in de request body, niet in het URL-pad.
+> Het maximale aantal domeinen per batch is 5.000.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Internet.nl batch API request-formaat
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** Internet.nl batch API - beperkingen
 
 - **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
   - *Bron status: unreachable*
@@ -390,9 +443,9 @@
 
 ### `inet-api-0023` — reference.md:59 *(§ Batch indienen)*
 
-> Het veld 'type' in de batch request body is verplicht en accepteert de waarden 'web' of 'mail'.
+> Het veld `type` in de batch request body is verplicht en accepteert de waarden `"web"` of `"mail"`.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Internet.nl batch API request-formaat
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Internet.nl batch API - request-formaat
 
 - **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
   - *Bron status: unreachable*
@@ -400,29 +453,29 @@
 
 ### `inet-api-0024` — reference.md:60 *(§ Batch indienen)*
 
-> Het veld 'domains' in de batch request body is verplicht en is een array van strings.
+> Het veld `domains` in de batch request body is verplicht en bevat een array van te testen domeinen.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Internet.nl batch API request-formaat
-
-- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
-  - *Bron status: unreachable*
-- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
-
-### `inet-api-0026` — reference.md:66 *(§ Beperkingen)*
-
-> Het maximum aantal domeinen per batch is 5.000.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** Internet.nl batch API beperkingen
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Internet.nl batch API - request-formaat
 
 - **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
   - *Bron status: unreachable*
 - **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
 
-### `inet-api-0027` — reference.md:67 *(§ Beperkingen)*
+### `inet-api-0025` — reference.md:66 *(§ Beperkingen)*
 
-> Het maximum aantal batch requests per week is 2.
+> Het maximale aantal domeinen per batch is 5.000.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** Internet.nl batch API beperkingen
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** Internet.nl batch API - beperkingen
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0026` — reference.md:67 *(§ Beperkingen)*
+
+> Het maximale aantal batch requests per week is 2.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** Internet.nl batch API - beperkingen
 
 - **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
   - *Bron status: unreachable*
@@ -430,9 +483,9 @@
 
 ### `inet-api-0039` — reference.md:393 *(§ TLS-velddetails sinds v1.11.0 (API v2.7.0))*
 
-> Een client die 'clientreneg' als boolean parseert, breekt op API v2.7.0; de parser moet worden aangepast op string-enum.
+> Een client die `clientreneg` als boolean parseert, breekt op API v2.7.0; de parser moet worden aangepast op string-enum.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Internet.nl batch API migratie v2.7.0
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Internet.nl batch API - migratie v2.7.0
 
 - **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
   - *Bron status: unreachable*

--- a/skills/inet-api/audit.md
+++ b/skills/inet-api/audit.md
@@ -1,0 +1,439 @@
+<!-- markdownlint-disable MD052 MD034 MD013 -->
+# Audit inet-api — 2026-05-17
+
+> Automatisch gegenereerd door audit-tooling. Niet handmatig bewerken; wijzig SKILL.md / reference.md en regenereer.
+
+## Samenvatting
+
+| Status | Aantal | % |
+|--------|--------|---|
+| UNSUPPORTED_ASSERTION | 34 | 83% |
+| CONTRADICTED | 0 | 0% |
+| PARTIALLY_GROUNDED | 1 | 2% |
+| UNGROUNDED | 6 | 15% |
+| NO_SOURCE | 0 | 0% |
+| UNVERIFIABLE | 0 | 0% |
+| KNOWN_DISCREPANCY | 0 | 0% |
+| GROUNDED | 0 | 0% |
+
+*Geverifieerd met sonnet, 2 calls, $0.1587.*
+
+## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (34)
+
+### `inet-api-0002` — SKILL.md:45 *(§ Toegang verkrijgen)*
+
+> Authenticatie bij de internet.nl batch API gaat via HTTP Basic Auth.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API authenticatie
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+  - *De aangeleverde brontekst is de GitHub README en bevat geen informatie over API-authenticatie.*
+
+### `inet-api-0003` — SKILL.md:52 *(§ API-workflow)*
+
+> De batch API werkt met een poll-model: batch indienen (POST) geeft een request-ID, daarna pollen op status tot 'done', dan resultaten ophalen.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API workflow
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+  - *Geen informatie over batch API workflow in de aangeleverde brontekst.*
+
+### `inet-api-0004` — SKILL.md:64 *(§ API-endpoints)*
+
+> Batch indienen (web of mail) gaat via POST naar /api/batch/v2/requests.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API endpoints
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0005` — SKILL.md:65 *(§ API-endpoints)*
+
+> Overzicht van eigen requests is opvraagbaar via GET /api/batch/v2/requests.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API endpoints
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0006` — SKILL.md:66 *(§ API-endpoints)*
+
+> Batchstatus opvragen gaat via GET /api/batch/v2/requests/{request_id}.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API endpoints
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0007` — SKILL.md:67 *(§ API-endpoints)*
+
+> Een batch annuleren gaat via PATCH /api/batch/v2/requests/{request_id}.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API endpoints
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0008` — SKILL.md:68 *(§ API-endpoints)*
+
+> Resultaten ophalen gaat via GET /api/batch/v2/requests/{request_id}/results.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API endpoints
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0009` — SKILL.md:69 *(§ API-endpoints)*
+
+> Technische resultaten zijn opvraagbaar via GET /api/batch/v2/requests/{request_id}/results_technical.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API endpoints
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0010` — SKILL.md:70 *(§ API-endpoints)*
+
+> Rapportage-metadata is opvraagbaar via GET /api/batch/v2/metadata/report.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API endpoints
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0011` — SKILL.md:72 *(§ API-endpoints)*
+
+> De base URL van de internet.nl batch API is https://batch.internet.nl.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API endpoints
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0013` — SKILL.md:75 *(§ API-endpoints)*
+
+> Het request_id is een 32-karakter hexadecimale string.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API request_id formaat
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0014` — SKILL.md:99 *(§ Batch indienen)*
+
+> Een batch submit response bevat de velden request_id, request_type en status ('registering').
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API response-formaat
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0015` — SKILL.md:139 *(§ Status opvragen en resultaten ophalen)*
+
+> Mogelijke batchstatussen zijn: registering, running, generating, done, error, cancelled.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API statuswaarden
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0016` — SKILL.md:321 *(§ Categorieen (webtest))*
+
+> De categorie 'appsecpriv' (webtest) omvat security headers en security.txt.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API webtest categorieën
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0017` — SKILL.md:318 *(§ Categorieen (webtest))*
+
+> De webtest categorieën zijn: ipv6, dnssec, tls, appsecpriv en rpki.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API webtest categorieën
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0018` — SKILL.md:327 *(§ Categorieen (mailtest))*
+
+> De mailtest categorieën zijn: ipv6, dnssec, auth (SPF, DKIM, DMARC), tls (STARTTLS, DANE, certificaat) en rpki.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API mailtest categorieën
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0019` — SKILL.md:393 *(§ Veelvoorkomende problemen)*
+
+> Bij grote batches (te veel domeinen tegelijk) kan een timeout optreden; de oplossing is splitsen in kleinere batches van maximaal 5.000 domeinen per batch.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API beperkingen
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0020` — SKILL.md:390 *(§ Veelvoorkomende problemen)*
+
+> HTTP 429 bij de batch API betekent dat de rate limit bereikt is.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API foutcodes
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0021` — reference.md:8 *(§ API-versie)*
+
+> De huidige versie van de internet.nl batch API is v2.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API versie
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0022` — reference.md:23 *(§ Authenticatie)*
+
+> De API gebruikt HTTP Basic Authentication via de Authorization-header: Basic base64(gebruikersnaam:wachtwoord).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API authenticatie
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0025` — reference.md:58 *(§ Batch indienen)*
+
+> Het veld 'name' in de batch request body is niet verplicht, heeft een maximum van 255 tekens en is bedoeld voor eigen administratie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API request-formaat
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0028` — reference.md:68 *(§ Beperkingen)*
+
+> Verwerking per gebruiker is sequentieel (FIFO), met 1 actieve batch tegelijk.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API beperkingen
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0029` — reference.md:70 *(§ Beperkingen)*
+
+> De beperkingen (max domeinen, max requests per week, FIFO) zijn vastgelegd in de Terms of Use op GitHub.
+
+**Type:** reference_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API beperkingen
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0030` — reference.md:263 *(§ Foutcodes)*
+
+> HTTP 400 bij de batch API betekent een ongeldige request; de actie is het controleren van het JSON-formaat en verplichte velden.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API foutcodes
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0031` — reference.md:264 *(§ Foutcodes)*
+
+> HTTP 401 bij de batch API betekent niet geautoriseerd; de actie is het controleren van credentials.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API foutcodes
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0032` — reference.md:266 *(§ Foutcodes)*
+
+> HTTP 404 bij de batch API betekent dat de batch niet gevonden is; de actie is het controleren van het request-ID.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API foutcodes
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0033` — reference.md:267 *(§ Foutcodes)*
+
+> HTTP 429 bij de batch API betekent dat de rate limit bereikt is.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API foutcodes
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0034` — reference.md:387 *(§ TLS-velddetails sinds v1.11.0 (API v2.7.0))*
+
+> Vanaf v1.11.0 (API v2.7.0) is het veld 'clientreneg' gewijzigd van boolean naar een string-enum: 'not_allowed' (good), 'allowed_with_low_limit' (info), 'allowed_with_too_high_limit' (failed).
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API TLS-velden v1.11.0
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0035` — reference.md:388 *(§ TLS-velddetails sinds v1.11.0 (API v2.7.0))*
+
+> Vanaf v1.11.0 (API v2.7.0) heeft het veld 'web_tls_ocsp'/'mail_tls_ocsp' een nieuwe statuswaarde 'not_in_cert' (not_tested) wanneer het certificaat geen OCSP-endpoint bevat; dit wordt niet als fout gerekend.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API TLS-velden v1.11.0
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0036` — reference.md:389 *(§ TLS-velddetails sinds v1.11.0 (API v2.7.0))*
+
+> Vanaf v1.11.0 (API v2.7.0) is het nieuwe veld 'web_tls_extended_master_secret'/'mail_tls_extended_master_secret' toegevoegd (RFC 7627) met statussen: 'supported' (good), 'not_supported' (failed), 'na_no_tls_1_2' (good), 'unknown' (not_tested).
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API TLS-velden v1.11.0
+
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7627.txt](https://www.rfc-editor.org/rfc/rfc7627.txt)
+  - *De bron is RFC 7627 zelf (de technische specificatie van de TLS Extended Master Secret extension). De claim gaat over de Internet.nl batch API v1.11.0/v2.7.0 en de specifieke veldnamen, statussen en versienummering in die API. Dat is implementatie-specifieke API-documentatie die niet in deze RFC staat.*
+
+### `inet-api-0037` — reference.md:390 *(§ TLS-velddetails sinds v1.11.0 (API v2.7.0))*
+
+> Vanaf v1.11.0 (API v2.7.0) zijn de statussen 'not_prescribed' en 'not_seclevel' voor 'web_tls_cipher_order' vervallen; verkeerde voorkeur of geen voorkeur is nu allebei 'bad'.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API TLS-velden v1.11.0
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0038` — reference.md:391 *(§ TLS-velddetails sinds v1.11.0 (API v2.7.0))*
+
+> Vanaf v1.11.0 (API v2.7.0) is het nieuwe veld 'cert_signature_phase_out' toegevoegd in TLS-details, naast 'cert_signature_bad', met een lijst van certificaat-signature-algoritmes op phase-out niveau (warning).
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API TLS-velden v1.11.0
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0040` — SKILL.md:308 *(§ Verdicts)*
+
+> De verdict-waarden in batch resultaten zijn: 'passed', 'warning', 'failed', 'info', 'not_tested'.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API resultatenstructuur
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0041` — reference.md:383 *(§ TLS-velddetails sinds v1.11.0 (API v2.7.0))*
+
+> De v1.11.0 release is gebaseerd op NCSC TLS-richtlijnen 2025-05.
+
+**Type:** version_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API versie v1.11.0
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+  - *De aangeleverde brontekst vermeldt wel release 1.11.0 als 'Latest Apr 21, 2026' in de releases-lijst, maar bevat geen inhoudelijke informatie over NCSC TLS-richtlijnen 2025-05 als basis voor die release.*
+
+## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (1)
+
+### `inet-api-0001` — SKILL.md:25 *(§ Overzicht)*
+
+> De internet.nl batch API maakt het mogelijk om meerdere domeinen tegelijk te testen op internetstandaarden.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl batch API algemeen
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **PARTIALLY_SUPPORTED** (medium) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+  > Internet.nl is an initiative of the Dutch Internet Standards Platform that helps you to check whether your website, email and internet connection use modern and reliable Internet Standards.
+  - *De bron bevestigt dat Internet.nl domeinen test op internetstandaarden, maar de batch API als specifieke functionaliteit wordt niet vermeld in de aangeleverde README-tekst.*
+
+## UNGROUNDED — geen bron ondersteunt de claim (6)
+
+### `inet-api-0012` — SKILL.md:74 *(§ API-endpoints)*
+
+> Het testtype ('web' of 'mail') wordt meegegeven in de request body, niet in het URL-pad.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Internet.nl batch API request-formaat
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0023` — reference.md:59 *(§ Batch indienen)*
+
+> Het veld 'type' in de batch request body is verplicht en accepteert de waarden 'web' of 'mail'.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Internet.nl batch API request-formaat
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0024` — reference.md:60 *(§ Batch indienen)*
+
+> Het veld 'domains' in de batch request body is verplicht en is een array van strings.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Internet.nl batch API request-formaat
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0026` — reference.md:66 *(§ Beperkingen)*
+
+> Het maximum aantal domeinen per batch is 5.000.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** Internet.nl batch API beperkingen
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0027` — reference.md:67 *(§ Beperkingen)*
+
+> Het maximum aantal batch requests per week is 2.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** Internet.nl batch API beperkingen
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+
+### `inet-api-0039` — reference.md:393 *(§ TLS-velddetails sinds v1.11.0 (API v2.7.0))*
+
+> Een client die 'clientreneg' als boolean parseert, breekt op API v2.7.0; de parser moet worden aangepast op string-enum.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Internet.nl batch API migratie v2.7.0
+
+- **SOURCE_UNAVAILABLE** (high) — [https://internet.nl/api/](https://internet.nl/api/)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)

--- a/skills/inet-mail/audit.md
+++ b/skills/inet-mail/audit.md
@@ -7,783 +7,690 @@
 
 | Status | Aantal | % |
 |--------|--------|---|
-| UNSUPPORTED_ASSERTION | 27 | 54% |
-| CONTRADICTED | 0 | 0% |
-| PARTIALLY_GROUNDED | 6 | 12% |
-| UNGROUNDED | 9 | 18% |
+| UNSUPPORTED_ASSERTION | 19 | 42% |
+| CONTRADICTED | 1 | 2% |
+| PARTIALLY_GROUNDED | 7 | 16% |
+| UNGROUNDED | 10 | 22% |
 | NO_SOURCE | 0 | 0% |
 | UNVERIFIABLE | 0 | 0% |
 | KNOWN_DISCREPANCY | 0 | 0% |
-| GROUNDED | 8 | 16% |
+| GROUNDED | 8 | 18% |
 
-*Geverifieerd met sonnet, 13 calls, $3.1525.*
+*Geverifieerd met sonnet, 11 calls, $2.4558.*
 
-## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (27)
+## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (19)
 
-### `inet-mail-0002` — SKILL.md:27 *(§ Overzicht)*
+### `inet-mail-0001` — SKILL.md:27 *(§ Overzicht)*
 
-> SPF, DKIM en DMARC staan op de pas-toe-of-leg-uit-lijst van Forum Standaardisatie.
+> SPF, DKIM, DMARC, STARTTLS en DANE staan op de pas-toe-of-leg-uit-lijst van Forum Standaardisatie.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie open standaarden
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Mailstandaarden / Forum Standaardisatie
+
+<details><summary>3x NOT_FOUND + 2x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (low) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
+  - *De brontekst is een navigatie-/lijstpagina van forumstandaardisatie.nl zonder de daadwerkelijke lijst van standaarden. SPF, DKIM, DMARC, STARTTLS en DANE worden niet bij naam genoemd. De pagina verwijst wel naar een 'Pas toe of leg uit'-lijst maar toont de inhoud daarvan niet.*
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *De brontekst vermeldt de Forum Standaardisatie pas-toe-of-leg-uit-lijst niet.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *De bron is RFC 7489 (technische DMARC-specificatie). De claim gaat over de Nederlandse Forum Standaardisatie pas-toe-of-leg-uit-lijst, wat een Nederlands beleidsregister is dat niet in deze RFC behandeld wordt.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De bron is RFC 6376 (DKIM technische specificatie). Bevat geen informatie over Forum Standaardisatie of pas-toe-of-leg-uit-lijsten.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *De bron is RFC 7208 (SPF-specificatie). Forum Standaardisatie en de pas-toe-of-leg-uit-lijst worden hier niet behandeld.*
+</details>
+
+### `inet-mail-0005` — SKILL.md:57 *(§ 1. SPF (Sender Policy Framework))*
+
+> Internet.nl test of het SPF-record eindigt op `-all` (fail) of `~all` (softfail).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** SPF / internet.nl testcriteria
 
 <details><summary>3x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *De bron vermeldt niets over Forum Standaardisatie of de pas-toe-of-leg-uit-lijst.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 bevat geen informatie over de pas-toe-of-leg-uit-lijst van Forum Standaardisatie.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *De bron is RFC 6376. De pas-toe-of-leg-uit-lijst van Forum Standaardisatie is een Nederlandse beleidsaangelegenheid die buiten scope van deze RFC valt.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *RFC 7208 behandelt geen Forum Standaardisatie of pas-toe-of-leg-uit-lijst.*
+  - *De brontekst beschrijft niet of internet.nl test op `-all` of `~all` in SPF-records.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *De claim gaat over internet.nl testcriteria voor SPF `-all`/`~all`. De bron is de DMARC RFC.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De bron gaat over DKIM, niet over SPF of internet.nl testcriteria.*
+- **NOT_FOUND** (medium) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *De bron beschrijft wat '-all' en '~all' betekenen, maar stelt nergens dat SPF-records op '-all' of '~all' moeten eindigen als testcriterium. Dat is een internet.nl-testcriterium, niet iets dat RFC 7208 voorschrijft.*
 </details>
 
-### `inet-mail-0004` — SKILL.md:54 *(§ 1. SPF (Sender Policy Framework))*
-
-> Internet.nl controleert of een SPF-record aanwezig is als DNS TXT-record.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl SPF-test
-
-<details><summary>2x NOT_FOUND + 2x OUT_OF_SCOPE (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *De bron noemt SPF maar beschrijft geen specifieke subtests.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 beschrijft DMARC, niet de specifieke werking van internet.nl als testplatform.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *Gaat over internet.nl SPF-test. De bron beschrijft DKIM, niet SPF of internet.nl.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *De bron beschrijft de SPF-standaard zelf, niet wat internet.nl controleert. De bron bevestigt wel dat SPF als DNS TXT-record gepubliceerd moet worden.*
-</details>
-
-### `inet-mail-0005` — SKILL.md:55 *(§ 1. SPF (Sender Policy Framework))*
-
-> Internet.nl controleert de correcte syntax van SPF-records.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl SPF-test
-
-<details><summary>2x NOT_FOUND + 2x OUT_OF_SCOPE (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over syntax-controle van SPF-records in de bron.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 beschrijft DMARC, niet de specifieke syntaxcontroles van internet.nl.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *Gaat over internet.nl SPF-syntaxcontrole. Buiten scope van RFC 6376.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *De bron beschrijft SPF-syntaxregels uitgebreid, maar zegt niets over wat internet.nl controleert.*
-</details>
-
-### `inet-mail-0007` — SKILL.md:57 *(§ 1. SPF (Sender Policy Framework))*
-
-> Internet.nl controleert of het SPF-record eindigt op `-all` (fail) of `~all` (softfail).
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl SPF-test
-
-<details><summary>2x NOT_FOUND + 2x OUT_OF_SCOPE (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over -all of ~all controle in de bron.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 beschrijft DMARC, niet de specifieke internet.nl-controle op `-all` of `~all`. Wel wordt SPF-beleid algemeen benoemd, maar de claim over internet.nl-testcriteria is buiten scope van deze bron.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *Gaat over SPF -all / ~all mechanisme. Buiten scope van RFC 6376.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *Wat internet.nl controleert valt buiten RFC 7208. De bron bespreekt wel -all en ~all als geldige qualifiers (fail resp. softfail), maar zegt niets over internet.nl-testcriteria.*
-</details>
-
-### `inet-mail-0009` — SKILL.md:103 *(§ 2. DKIM (DomainKeys Identified Mail))*
+### `inet-mail-0008` — SKILL.md:103 *(§ 2. DKIM (DomainKeys Identified Mail))*
 
 > Internet.nl test of minimaal 1 geldige DKIM-handtekening aanwezig is op de testmail.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl DKIM-test
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DKIM / internet.nl testcriteria
 
-<details><summary>3x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+<details><summary>2x NOT_FOUND + 2x OUT_OF_SCOPE (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over specifieke DKIM-subtests in de bron.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 beschrijft DMARC, niet de specifieke werking van internet.nl als testplatform.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *De claim gaat over internet.nl's testgedrag. RFC 6376 beschrijft het protocol, niet hoe internet.nl test.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *DKIM en internet.nl vallen buiten scope van RFC 7208.*
+  - *De brontekst noemt DKIM maar geeft geen detail over het testen van DKIM-handtekeningen op testmail.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *De claim gaat over internet.nl testcriteria voor DKIM-handtekeningen. De bron is de DMARC RFC, niet internet.nl documentatie.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De bron beschrijft de DKIM-standaard zelf, niet de internet.nl testcriteria.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *DKIM wordt niet behandeld in RFC 7208. Dit is een SPF-specificatie.*
 </details>
 
-### `inet-mail-0011` — SKILL.md:106 *(§ 2. DKIM (DomainKeys Identified Mail))*
+### `inet-mail-0010` — SKILL.md:106 *(§ 2. DKIM (DomainKeys Identified Mail))*
 
 > Internet.nl controleert alleen of een DKIM-record bestaat; de sleutellengte wordt niet getest.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl DKIM-test
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DKIM / internet.nl testcriteria
+
+<details><summary>2x NOT_FOUND + 2x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *De brontekst geeft geen details over wat internet.nl wel of niet controleert bij DKIM.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *De claim gaat over internet.nl testcriteria voor DKIM sleutellengte. De bron is de DMARC RFC.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De bron beschrijft de DKIM-standaard, niet de internet.nl testcriteria over wel of niet testen van sleutellengte.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *DKIM wordt niet behandeld in RFC 7208.*
+</details>
+
+### `inet-mail-0014` — SKILL.md:151 *(§ 3. DMARC (Domain-based Message Authentication, Reporting and Conformance))*
+
+> Internet.nl scoort alleen DMARC `p=quarantine` of `p=reject` als voldoende; `p=none` is onvoldoende.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DMARC / internet.nl testcriteria
 
 <details><summary>3x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over sleutellengte-controle of het ontbreken daarvan in de bron.*
+  - *De brontekst vermeldt DMARC maar geeft geen detail over hoe `p=none` versus `p=quarantine`/`p=reject` wordt beoordeeld.*
 - **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 beschrijft DMARC, niet de specifieke internet.nl-testcriteria voor sleutellengte.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *De claim gaat over wat internet.nl wel of niet controleert. RFC 6376 beschrijft het protocol, niet de testmethodologie van internet.nl.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *DKIM en internet.nl vallen buiten scope van RFC 7208.*
+  - *De bron beschrijft de DMARC-beleidswaarden `none`, `quarantine` en `reject`, maar maakt geen uitspraak over internet.nl scoringscriteria of dat `p=none` als onvoldoende wordt beoordeeld.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De bron gaat over DKIM, niet over DMARC of internet.nl testcriteria.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *DMARC wordt niet behandeld in RFC 7208.*
 </details>
 
-### `inet-mail-0015` — SKILL.md:151 *(§ 3. DMARC (Domain-based Message Authentication, Reporting and Conformance))*
-
-> Internet.nl test of het DMARC-beleid `quarantine` of `reject` is; `none` is onvoldoende voor productie.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl DMARC-test
-
-<details><summary>3x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over specifieke DMARC-beleidscontroles in de bron.*
-- **NOT_FOUND** (medium) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 beschrijft de DMARC-beleidsopties (none, quarantine, reject) maar bevat geen uitspraak over wat internet.nl als 'voldoende voor productie' beschouwt. De bron beschrijft wel dat 'p=none' geen actie verzoekt, maar dat is een andere claim dan wat internet.nl beoordeelt.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *De claim gaat over internet.nl DMARC-testen en DMARC-beleid (quarantine/reject). RFC 6376 behandelt DMARC niet.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *DMARC en internet.nl vallen buiten scope van RFC 7208.*
-</details>
-
-### `inet-mail-0016` — SKILL.md:152 *(§ 3. DMARC (Domain-based Message Authentication, Reporting and Conformance))*
+### `inet-mail-0015` — SKILL.md:152 *(§ 3. DMARC (Domain-based Message Authentication, Reporting and Conformance))*
 
 > Internet.nl test of een DMARC rapportage-adres (rua) geconfigureerd is.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl DMARC-test
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DMARC / internet.nl testcriteria
 
 <details><summary>3x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over rua-rapportageadres check in de bron.*
+  - *Het testen van een DMARC rua-adres wordt niet beschreven in de brontekst.*
 - **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 beschrijft DMARC inclusief de rua-tag, maar bevat geen uitspraak over wat internet.nl test.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *De bron is RFC 6376 over DKIM. DMARC wordt niet behandeld in deze RFC.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *DMARC en internet.nl vallen buiten scope van RFC 7208.*
-</details>
-
-### `inet-mail-0018` — SKILL.md:156 *(§ 3. DMARC (Domain-based Message Authentication, Reporting and Conformance))*
-
-> Internet.nl scoort alleen DMARC-beleid `quarantine` of `reject` als voldoende.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl DMARC-test
-
-<details><summary>2x NOT_FOUND + 2x OUT_OF_SCOPE (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over scoren van DMARC-beleid in de bron.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 beschrijft DMARC-beleid (none, quarantine, reject) maar bevat geen informatie over internet.nl scoringscriteria of wat als 'voldoende' wordt beschouwd.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *De bron is RFC 6376 over DKIM. Internet.nl DMARC-scoring wordt niet behandeld.*
+  - *De bron beschrijft de `rua`-tag uitgebreid, maar maakt geen uitspraak over internet.nl testcriteria die controleren of een rua-adres geconfigureerd is.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De bron gaat over DKIM, niet over DMARC of internet.nl testcriteria.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *De bron is RFC 7208 over SPF. DMARC en internet.nl scoringslogica komen niet voor in deze spec.*
+  - *DMARC wordt niet behandeld in RFC 7208.*
 </details>
 
-### `inet-mail-0019` — SKILL.md:201 *(§ 4. STARTTLS)*
+### `inet-mail-0019` — SKILL.md:205 *(§ 4. STARTTLS)*
 
-> STARTTLS versleutelt SMTP-verkeer tussen mailservers.
+> Internet.nl test of MX-servers TLS 1.2 of hoger ondersteunen; TLS 1.0/1.1 geeft een phase-out waarschuwing en SSL 2.0/3.0 is een harde fout.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** STARTTLS
-
-<details><summary>2x NOT_FOUND + 2x OUT_OF_SCOPE (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *De bron noemt STARTTLS maar geeft geen technische beschrijving van de werking.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 gaat over DMARC. STARTTLS wordt niet besproken in deze bron.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *De bron is RFC 6376 over DKIM. STARTTLS wordt niet behandeld.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *RFC 7208 gaat over SPF, niet over STARTTLS.*
-</details>
-
-### `inet-mail-0020` — SKILL.md:204 *(§ 4. STARTTLS)*
-
-> Internet.nl test of MX-servers STARTTLS ondersteunen.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl STARTTLS-test
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** STARTTLS / internet.nl testcriteria
 
 <details><summary>1x NOT_FOUND + 3x OUT_OF_SCOPE (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over specifieke STARTTLS-subtests in de bron.*
+  - *De brontekst geeft geen detail over TLS-versiecontroles of phase-out waarschuwingen.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 beschrijft DMARC, niet internet.nl testmethodologie of STARTTLS-tests.*
+  - *De bron is RFC 7489 (DMARC). TLS-versievereisten voor MX-servers en internet.nl testcriteria worden niet behandeld.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *De bron is RFC 6376 over DKIM. Internet.nl STARTTLS-tests worden niet behandeld.*
+  - *RFC 6376 gaat over DKIM-signatures, niet over internet.nl TLS-versietests voor MX-servers.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *RFC 7208 gaat over SPF, niet over internet.nl STARTTLS-tests.*
+  - *De bron is RFC 7208 over SPF. TLS-versievereisten en internet.nl testcriteria zijn buiten scope.*
 </details>
 
-### `inet-mail-0021` — SKILL.md:205 *(§ 4. STARTTLS)*
-
-> Internet.nl test of MX-servers TLS 1.2 of hoger ondersteunen; TLS 1.0/1.1 geeft een phase-out waarschuwing; SSL 2.0/3.0 is een harde fout.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl STARTTLS-test TLS-versies
-
-<details><summary>1x NOT_FOUND + 3x OUT_OF_SCOPE (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over TLS-versiecontroles in de bron.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 beschrijft DMARC, niet internet.nl TLS-versietests.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *De bron is RFC 6376 over DKIM. TLS-versievereisten voor MX-servers worden niet behandeld.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *RFC 7208 gaat over SPF, niet over TLS-versievereisten of internet.nl tests.*
-</details>
-
-### `inet-mail-0022` — SKILL.md:206 *(§ 4. STARTTLS)*
+### `inet-mail-0020` — SKILL.md:206 *(§ 4. STARTTLS)*
 
 > Internet.nl test of MX-servers een geldig certificaat hebben voor STARTTLS.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl STARTTLS-test
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** STARTTLS / internet.nl testcriteria
 
 <details><summary>1x NOT_FOUND + 3x OUT_OF_SCOPE (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over certificaatvalidatie in STARTTLS-test in de bron.*
+  - *Certificaatvalidatie voor STARTTLS wordt niet beschreven in de brontekst.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 beschrijft DMARC, niet internet.nl certificaatvalidatietests.*
+  - *De bron is RFC 7489 (DMARC). Certificaatvalidatie voor STARTTLS en internet.nl testcriteria vallen buiten scope.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *De bron is RFC 6376 over DKIM. Certificaatvalidatie voor STARTTLS wordt niet behandeld.*
+  - *RFC 6376 gaat over DKIM-signatures, niet over internet.nl certificaatvalidatie voor STARTTLS.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *RFC 7208 gaat over SPF, niet over certificaatvalidatie bij STARTTLS.*
+  - *De bron is RFC 7208 over SPF. Certificaatvalidatie voor STARTTLS is buiten scope.*
 </details>
 
-### `inet-mail-0023` — SKILL.md:207 *(§ 4. STARTTLS)*
+### `inet-mail-0021` — SKILL.md:207 *(§ 4. STARTTLS)*
 
-> Internet.nl test of MX-servers geen terugval naar onversleuteld verkeer toestaan.
+> Internet.nl test of MX-servers geen terugval naar onversleuteld verkeer hebben bij STARTTLS.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl STARTTLS-test
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** STARTTLS / internet.nl testcriteria
 
 <details><summary>1x NOT_FOUND + 3x OUT_OF_SCOPE (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over downgrade-protection test in de bron.*
+  - *Testen op terugval naar onversleuteld verkeer wordt niet beschreven in de brontekst.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 beschrijft DMARC, niet internet.nl downgrade-protectietests.*
+  - *De bron is RFC 7489 (DMARC). Terugval naar onversleuteld verkeer bij STARTTLS wordt niet behandeld.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *De bron is RFC 6376 over DKIM. Downgrade-bescherming voor STARTTLS wordt niet behandeld.*
+  - *RFC 6376 gaat over DKIM-signatures, niet over internet.nl downgrade-tests voor STARTTLS.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *RFC 7208 gaat over SPF, niet over downgrade-bescherming bij STARTTLS.*
+  - *De bron is RFC 7208 over SPF. STARTTLS downgrade-bescherming is buiten scope.*
 </details>
 
-### `inet-mail-0026` — SKILL.md:229 *(§ 5. DANE (DNS-based Authentication of Named Entities))*
+### `inet-mail-0023` — SKILL.md:229 *(§ 5. DANE (DNS-based Authentication of Named Entities))*
 
-> Internet.nl test of TLSA-records aanwezig zijn voor MX-servers.
+> Internet.nl test of TLSA-records aanwezig zijn voor MX-servers bij DANE.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl DANE-test
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DANE / internet.nl testcriteria
 
 <details><summary>1x NOT_FOUND + 3x OUT_OF_SCOPE (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over TLSA-record aanwezigheidscheck in de bron.*
+  - *Het testen van TLSA-records wordt niet beschreven in de brontekst.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 beschrijft DMARC, niet internet.nl DANE-tests of TLSA-records.*
+  - *De bron is RFC 7489 (DMARC). DANE TLSA-records en internet.nl testcriteria worden niet behandeld.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *De bron is RFC 6376 over DKIM. Internet.nl DANE-tests worden niet behandeld.*
+  - *RFC 6376 gaat over DKIM-signatures, niet over internet.nl DANE/TLSA-tests.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *RFC 7208 gaat over SPF, niet over internet.nl DANE-tests.*
+  - *De bron is RFC 7208 over SPF. DANE TLSA-records en internet.nl testcriteria zijn buiten scope.*
 </details>
 
-### `inet-mail-0027` — SKILL.md:230 *(§ 5. DANE (DNS-based Authentication of Named Entities))*
+### `inet-mail-0024` — SKILL.md:230 *(§ 5. DANE (DNS-based Authentication of Named Entities))*
 
-> Internet.nl test of TLSA-parameters correct zijn voor MX-servers.
+> Internet.nl test of TLSA-records correcte parameters hebben voor DANE.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl DANE-test
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DANE / internet.nl testcriteria
 
 <details><summary>1x NOT_FOUND + 3x OUT_OF_SCOPE (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over TLSA-parametercontroles in de bron.*
+  - *TLSA-recordparameters worden niet beschreven in de brontekst.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 beschrijft DMARC, niet internet.nl TLSA-parametertests.*
+  - *De bron is RFC 7489 (DMARC). DANE TLSA-parameters worden niet behandeld.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *De bron is RFC 6376 over DKIM. TLSA-parametervalidatie wordt niet behandeld.*
+  - *RFC 6376 gaat over DKIM-signatures, niet over internet.nl TLSA-parametervalidatie.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *RFC 7208 gaat over SPF, niet over TLSA-parametervalidatie.*
+  - *De bron is RFC 7208 over SPF. DANE TLSA-parameters zijn buiten scope.*
 </details>
 
-### `inet-mail-0028` — SKILL.md:231 *(§ 5. DANE (DNS-based Authentication of Named Entities))*
+### `inet-mail-0025` — SKILL.md:231 *(§ 5. DANE (DNS-based Authentication of Named Entities))*
 
-> Internet.nl test of DNSSEC actief is op het MX-domein.
+> Internet.nl test of DNSSEC actief is op het MX-domein bij DANE.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl DANE-test
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DANE / internet.nl testcriteria
 
 <details><summary>1x NOT_FOUND + 3x OUT_OF_SCOPE (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over DNSSEC-controle in DANE-test in de bron.*
+  - *Het testen van DNSSEC bij DANE wordt niet beschreven in de brontekst.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 beschrijft DMARC, niet internet.nl DNSSEC-tests voor MX-domeinen.*
+  - *De bron is RFC 7489 (DMARC). DNSSEC op MX-domein bij DANE wordt niet behandeld.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *De bron is RFC 6376 over DKIM. DNSSEC-vereisten voor MX-domeinen worden niet behandeld.*
+  - *RFC 6376 gaat over DKIM-signatures, niet over internet.nl DNSSEC-tests bij DANE.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *RFC 7208 gaat over SPF, niet over internet.nl DANE/DNSSEC-tests.*
+  - *De bron is RFC 7208 over SPF. DNSSEC-vereisten voor DANE zijn buiten scope.*
 </details>
 
-### `inet-mail-0032` — SKILL.md:282 *(§ Veelvoorkomende problemen)*
+### `inet-mail-0027` — SKILL.md:244 *(§ 5. DANE (DNS-based Authentication of Named Entities))*
 
-> Een DANE TLSA mismatch treedt op als het certificaat vernieuwd is zonder het TLSA-record bij te werken.
+> DANE Selector `1` staat voor SubjectPublicKeyInfo (publieke sleutel) in TLSA-records.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DANE veelvoorkomende problemen
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DANE / TLSA-parameters
 
-<details><summary>3x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+<details><summary>1x NOT_FOUND + 3x OUT_OF_SCOPE (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over DANE TLSA mismatch in de bron.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 beschrijft DMARC, niet DANE TLSA-mismatches bij certificaatvernieuwing.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *DANE en TLSA-records worden niet behandeld in deze DKIM-specificatie.*
+  - *TLSA Selector-waarden worden niet beschreven in de brontekst.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *De bron is RFC 7489 (DMARC). DANE TLSA Selector-waarden worden niet behandeld.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *RFC 6376 gaat over DKIM-signatures, niet over DANE TLSA Selector-waarden.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *RFC 7208 gaat over SPF, niet over DANE TLSA mismatches bij certificaatvernieuwing.*
+  - *De bron is RFC 7208 over SPF. DANE Selector parameters zijn buiten scope.*
 </details>
 
-### `inet-mail-0034` — reference.md:23 *(§ STARTTLS inschakelen)*
+### `inet-mail-0028` — SKILL.md:245 *(§ 5. DANE (DNS-based Authentication of Named Entities))*
 
-> Postfix `smtp_tls_security_level = dane` configureert uitgaande verbindingen om DANE te gebruiken.
+> DANE Matching Type `1` staat voor SHA-256 hash in TLSA-records.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Postfix DANE configuratie
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DANE / TLSA-parameters
 
-<details><summary>3x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+<details><summary>1x NOT_FOUND + 3x OUT_OF_SCOPE (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over Postfix DANE-configuratie in de bron.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 behandelt geen Postfix-configuratie of DANE.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *Postfix DANE-configuratie wordt niet behandeld in deze DKIM-specificatie.*
+  - *TLSA Matching Type-waarden worden niet beschreven in de brontekst.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *De bron is RFC 7489 (DMARC). DANE TLSA Matching Type-waarden worden niet behandeld.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *RFC 6376 gaat over DKIM-signatures, niet over DANE TLSA Matching Type-waarden.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *De bron is RFC 7208 (SPF-protocol). Postfix DANE-configuratie valt buiten het bereik van deze specificatie.*
+  - *De bron is RFC 7208 over SPF. DANE Matching Type parameters zijn buiten scope.*
 </details>
 
-### `inet-mail-0036` — reference.md:95 *(§ Microsoft Exchange / Microsoft 365)*
+### `inet-mail-0030` — SKILL.md:282 *(§ Veelvoorkomende problemen)*
 
-> SPF voor Microsoft 365 gebruikt het mechanisme `include:spf.protection.outlook.com`.
+> Een DANE TLSA mismatch treedt op wanneer een certificaat vernieuwd wordt zonder het TLSA-record bij te werken.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Microsoft 365 SPF-configuratie
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DANE / veelvoorkomende problemen
 
-<details><summary>4x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over Microsoft 365 SPF-configuratie in de bron.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 behandelt geen Microsoft 365-specifieke SPF-configuratie.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *SPF en Microsoft 365-specifieke configuratie worden niet behandeld in RFC 6376.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *De bron beschrijft de SPF-standaard algemeen maar noemt geen Microsoft 365-specifieke include-mechanismen.*
-</details>
-
-### `inet-mail-0037` — reference.md:100 *(§ Microsoft Exchange / Microsoft 365)*
-
-> DKIM voor Microsoft 365 wordt geconfigureerd via het Microsoft 365 Defender-portaal onder Email & Collaboration > Policies > DKIM.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Microsoft 365 DKIM-configuratie
-
-<details><summary>3x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+<details><summary>1x NOT_FOUND + 3x OUT_OF_SCOPE (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over Microsoft 365 DKIM-configuratie in de bron.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 behandelt geen Microsoft 365 Defender-portaal of DKIM-configuratie daarin.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *Microsoft 365 Defender-portaal en platform-specifieke DKIM-configuratie vallen buiten de scope van RFC 6376.*
+  - *DANE TLSA mismatch bij certificaatvernieuwing wordt niet beschreven in de brontekst.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *De bron is RFC 7489 (DMARC). DANE TLSA mismatch bij certificaatvernieuwing wordt niet behandeld.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *RFC 6376 gaat over DKIM-signatures, niet over DANE TLSA mismatch bij certificaatverlenging.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *De bron is RFC 7208 (SPF-protocol). DKIM-configuratie via Microsoft 365 Defender-portaal valt buiten het bereik van deze specificatie.*
+  - *De bron is RFC 7208 over SPF. DANE TLSA mismatch bij certificaatvernieuwing is buiten scope.*
 </details>
 
-### `inet-mail-0038` — reference.md:107 *(§ Microsoft Exchange / Microsoft 365)*
+### `inet-mail-0040` — reference.md:215 *(§ Forensische rapporten (ruf))*
 
-> Microsoft 365 DKIM gebruikt CNAME-records die verwijzen naar `selector1-example-nl._domainkey.example.onmicrosoft.com` en `selector2-example-nl._domainkey.example.onmicrosoft.com`.
+> Niet alle mailproviders versturen forensische DMARC ruf-rapporten.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Microsoft 365 DKIM DNS-configuratie
-
-<details><summary>3x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over Microsoft 365 CNAME-records in de bron.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 bevat geen informatie over Microsoft 365 DKIM CNAME-records.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *Microsoft 365-specifieke CNAME-records worden niet behandeld in RFC 6376.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *De bron is RFC 7208 (SPF-protocol). Microsoft 365 DKIM CNAME-records vallen buiten het bereik van deze specificatie.*
-</details>
-
-### `inet-mail-0039` — reference.md:122 *(§ Google Workspace)*
-
-> SPF voor Google Workspace gebruikt het mechanisme `include:_spf.google.com`.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Google Workspace SPF-configuratie
-
-<details><summary>4x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over Google Workspace SPF-configuratie in de bron.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 behandelt geen Google Workspace SPF-configuratie.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *Google Workspace SPF-configuratie valt buiten de scope van RFC 6376.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *De bron beschrijft de SPF-standaard algemeen maar noemt geen Google Workspace-specifieke include-mechanismen.*
-</details>
-
-### `inet-mail-0045` — reference.md:215 *(§ Forensische rapporten (ruf))*
-
-> Niet alle mailproviders versturen forensische DMARC-rapporten (ruf).
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DMARC forensische rapportage
-
-<details><summary>3x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over forensische DMARC-rapporten in de bron.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 beschrijft het mechanisme voor forensische rapporten (ruf-tag) maar zegt niets over of mailproviders deze al dan niet versturen in de praktijk.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *DMARC forensische rapporten (ruf) worden niet behandeld in RFC 6376 over DKIM.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *De bron is RFC 7208 (SPF-protocol). DMARC forensische rapportage valt buiten het bereik van deze specificatie.*
-</details>
-
-### `inet-mail-0046` — reference.md:241 *(§ TLSA bijwerken bij certificaatvernieuwing)*
-
-> Bij DANE met DANE-EE (3) + SPKI (1) telt alleen de publieke sleutel, niet het volledige certificaat, zodat bij hergebruik van dezelfde privesleutel het TLSA-record niet hoeft te veranderen.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DANE TLSA certificaatvernieuwing
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DMARC / forensische rapporten
 
 <details><summary>2x NOT_FOUND + 2x OUT_OF_SCOPE (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over DANE-EE en sleutelhergebruik in de bron.*
+  - *Forensische DMARC ruf-rapporten worden niet beschreven in de brontekst.*
 - **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 behandelt geen DANE TLSA-records, DANE-EE of SPKI-selectors.*
+  - *RFC 7489 beschrijft het mechanisme voor ruf-rapporten maar stelt nergens expliciet dat niet alle mailproviders forensische rapporten versturen.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *RFC 6376 gaat over DKIM-handtekeningen, niet over DANE of TLSA-records. De bron bevat geen informatie over DANE-EE, SPKI-selectors of TLSA-certificaatvernieuwing.*
+  - *De bron beschrijft DKIM signatures. DMARC forensische rapporten vallen buiten de scope van RFC 6376.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *De bron is RFC 7208 (SPF-protocol). DANE TLSA certificaatvernieuwing valt buiten het bereik van deze specificatie.*
+  - *De bron gaat over SPF. DMARC forensische rapporten worden niet behandeld.*
 </details>
 
-### `inet-mail-0048` — reference.md:262 *(§ MTA-STS configuratie)*
+### `inet-mail-0041` — reference.md:241 *(§ TLSA bijwerken bij certificaatvernieuwing)*
 
-> MTA-STS wordt niet getest door internet.nl en is een aanvullende best practice naast DANE.
+> Bij DANE met DANE-EE (3) + SPKI (1) telt alleen de publieke sleutel, niet het volledige certificaat; als dezelfde privesleutel wordt hergebruikt bij vernieuwing hoeft het TLSA-record niet te veranderen.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** MTA-STS
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DANE / TLSA-beheer bij certificaatvernieuwing
 
-<details><summary>3x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+<details><summary>1x NOT_FOUND + 3x OUT_OF_SCOPE (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over MTA-STS in de bron.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 beschrijft uitsluitend DMARC. MTA-STS wordt nergens in de brontekst genoemd.*
+  - *DANE-EE SPKI-gedrag bij certificaatvernieuwing wordt niet beschreven in de brontekst.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 gaat over DMARC, niet over DANE TLSA-records of DANE-EE certificaatbeheer.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *RFC 6376 gaat over DKIM-handtekeningen, niet over MTA-STS of internet.nl-tests.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *RFC 7208 behandelt uitsluitend SPF (Sender Policy Framework). MTA-STS wordt nergens in de brontekst genoemd.*
+  - *De bron beschrijft DKIM signatures. DANE TLSA-records en certificaatbeheer vallen buiten de scope van RFC 6376.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *De bron gaat over SPF. DANE TLSA-records en DANE-EE worden niet behandeld.*
 </details>
 
-### `inet-mail-0050` — reference.md:291 *(§ SMTP TLS Reporting (TLSRPT))*
+### `inet-mail-0043` — reference.md:262 *(§ MTA-STS configuratie)*
+
+> MTA-STS wordt niet getest door internet.nl; het is een aanvullende best practice naast DANE.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** MTA-STS / internet.nl
+
+<details><summary>1x NOT_FOUND + 3x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *MTA-STS wordt niet vermeld in de brontekst.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 gaat over DMARC, niet over MTA-STS of internet.nl tests.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De bron beschrijft DKIM signatures. MTA-STS en internet.nl-testen vallen buiten de scope van RFC 6376.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *De bron gaat over SPF. MTA-STS en internet.nl worden niet behandeld.*
+</details>
+
+### `inet-mail-0045` — reference.md:291 *(§ SMTP TLS Reporting (TLSRPT))*
 
 > SMTP TLS Reporting (TLSRPT) gebruikt een DNS TXT-record op `_smtp._tls.example.nl` met formaat `v=TLSRPTv1; rua=mailto:...` om rapporten te ontvangen over TLS-fouten.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** SMTP TLS Reporting (TLSRPT)
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** TLSRPT / DNS-record
 
-<details><summary>3x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+<details><summary>1x NOT_FOUND + 3x OUT_OF_SCOPE (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over SMTP TLS Reporting in de bron.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *SMTP TLS Reporting (TLSRPT) wordt niet vermeld in RFC 7489. De bron behandelt uitsluitend DMARC-rapportage via rua/ruf tags.*
+  - *SMTP TLS Reporting (TLSRPT) wordt niet beschreven in de brontekst.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 gaat over DMARC, niet over SMTP TLS Reporting (TLSRPT) DNS-records.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *RFC 6376 gaat over DKIM-handtekeningen, niet over SMTP TLS Reporting (TLSRPT) of bijbehorende DNS-records.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *RFC 7208 behandelt uitsluitend SPF. SMTP TLS Reporting (TLSRPT) en het bijbehorende DNS-record op _smtp._tls worden nergens in de brontekst vermeld.*
+  - *De bron beschrijft DKIM signatures. SMTP TLS Reporting (TLSRPT) valt buiten de scope van RFC 6376.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *De bron gaat over SPF. SMTP TLS Reporting (TLSRPT) en bijbehorende DNS-records worden niet behandeld.*
 </details>
 
-## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (6)
+## CONTRADICTED — bron spreekt de claim expliciet tegen (1)
 
-### `inet-mail-0006` — SKILL.md:56 *(§ 1. SPF (Sender Policy Framework))*
+### `inet-mail-0006` — SKILL.md:74 *(§ 1. SPF (Sender Policy Framework))*
 
-> Internet.nl controleert of SPF maximaal 10 DNS-lookups gebruikt (include, a, mx, redirect).
+> Het SPF-mechanisme `include:domein` neemt het SPF-beleid van een ander domein over.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl SPF-test
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** SPF mechanismen
 
-- **PARTIALLY_SUPPORTED** (medium) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  > SPF implementations MUST limit the total number of those terms to 10 during SPF evaluation, to avoid unreasonable load on the DNS. If this limit is exceeded, the implementation MUST return "permerror". The following terms cause DNS queries: the "include", "a", "mx", "ptr", and "exists" mechanisms, and the "redirect" modifier.
-  - *De bron bevestigt de 10-DNS-lookup-limiet en noemt include, a, mx en redirect als lookup-veroorzakers. De claim over internet.nl die dit controleert valt buiten scope van de bron. De genoemde mechanismen kloppen inhoudelijk, maar de bron noemt ook 'ptr' en 'exists' als lookup-veroorzakers, die de claim weglaat.*
+- **CONTRADICTED** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  > In hindsight, the name "include" was poorly chosen. Only the evaluated result of the referenced SPF record is used, rather than literally including the mechanisms of the referenced record in the first.
+  - *De claim zegt dat 'include' het SPF-beleid van een ander domein 'overneemt', maar de bron stelt expliciet dat alleen het evaluatieresultaat wordt gebruikt, niet de mechanismen letterlijk worden overgenomen.*
 <details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over DNS-lookup limieten in de bron.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 beschrijft DMARC, niet de specifieke SPF-lookup-limietcontrole van internet.nl. De 10-lookup-limiet is onderdeel van de SPF-specificatie (RFC 7208), niet van RFC 7489.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *Gaat over SPF DNS-lookup limiet. Buiten scope van RFC 6376.*
+  - *SPF-mechanismen worden niet beschreven in de brontekst.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *De claim gaat over het SPF `include:`-mechanisme. De bron is de DMARC RFC, niet de SPF-specificatie (RFC 7208).*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De bron gaat over DKIM, niet over SPF-mechanismen.*
 </details>
 
-### `inet-mail-0010` — SKILL.md:104 *(§ 2. DKIM (DomainKeys Identified Mail))*
+## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (7)
+
+### `inet-mail-0009` — SKILL.md:104 *(§ 2. DKIM (DomainKeys Identified Mail))*
 
 > Internet.nl test of de DKIM publieke sleutel beschikbaar is via DNS.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl DKIM-test
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DKIM / internet.nl testcriteria
 
 - **PARTIALLY_SUPPORTED** (medium) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  > The public key for a signature is needed to complete the verification process. The process of retrieving the public key depends on the query type as defined by the "q=" tag in the DKIM-Signature header field.
-  - *RFC 6376 bevestigt dat de publieke sleutel via DNS beschikbaar moet zijn voor verificatie, maar beschrijft niet wat internet.nl specifiek test. Het DNS-opzoekingsaspect wordt volledig ondersteund; het 'internet.nl'-gedeelte is out of scope.*
-<details><summary>3x NOT_FOUND (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over DKIM DNS-beschikbaarheid check in de bron.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 beschrijft DMARC, niet de specifieke internet.nl-controle op beschikbaarheid van DKIM publieke sleutels.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *DKIM en internet.nl vallen buiten scope van RFC 7208.*
-</details>
-
-### `inet-mail-0024` — SKILL.md:222 *(§ 5. DANE (DNS-based Authentication of Named Entities))*
-
-> DANE koppelt TLS-certificaten aan DNS via TLSA-records, beveiligd met DNSSEC.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DANE (DNS-based Authentication of Named Entities)
-
-- **PARTIALLY_SUPPORTED** (low) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  > To reduce the risk of subversion of the DMARC mechanism due to DNS-based exploits, serious consideration should be given to the deployment of DNSSEC in parallel with the deployment of DMARC by both Domain Owners and Mail Receivers.
-  - *RFC 7489 noemt DNSSEC als aanbeveling naast DMARC, maar behandelt DANE of TLSA-records niet expliciet. De claim over DANE koppeling via TLSA-records is niet te verifiëren vanuit deze bron.*
+  > Parameters to the key lookup algorithm are the type of the lookup (the "q=" tag), the domain of the Signer (the "d=" tag of the DKIM-Signature header field), and the selector (the "s=" tag). [...] This document defines a single binding, using DNS TXT RRs to distribute the keys.
+  - *De bron bevestigt dat de publieke sleutel via DNS beschikbaar moet zijn (DNS TXT RR), wat de technische basis is van de claim. De bron zegt echter niets over internet.nl testcriteria specifiek.*
 <details><summary>1x NOT_FOUND + 2x OUT_OF_SCOPE (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *De bron noemt DANE maar geeft geen technische beschrijving van TLSA of DNSSEC-koppeling.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *De bron is RFC 6376 over DKIM. DANE en TLSA-records worden niet behandeld.*
+  - *De beschikbaarheid van DKIM publieke sleutels via DNS wordt niet beschreven in de brontekst.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *De claim gaat over internet.nl testcriteria voor DKIM DNS-beschikbaarheid. De bron is de DMARC RFC.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *RFC 7208 gaat over SPF, niet over DANE of TLSA-records.*
+  - *DKIM wordt niet behandeld in RFC 7208.*
 </details>
 
-### `inet-mail-0041` — reference.md:141 *(§ DKIM key rotation)*
+### `inet-mail-0016` — SKILL.md:154 *(§ 3. DMARC (Domain-based Message Authentication, Reporting and Conformance))*
+
+> Het DMARC-implementatiepad start met `p=none` om rapportages te verzamelen, daarna `p=quarantine` en uiteindelijk `p=reject`.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** DMARC / implementatiepad
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  > To enable Domain Owners to receive DMARC feedback without impacting existing mail processing, discovered policies of "p=none" SHOULD NOT modify existing mail disposition processing.
+  - *De bron ondersteunt impliciet een implementatiepad waarbij `p=none` wordt gebruikt voor monitoring zonder impact op mailaflevering. De specifieke fasering (none → quarantine → reject) als aanbevolen pad wordt niet expliciet als stappenplan beschreven in de bron; de bron beschrijft de `pct`-tag voor geleidelijke uitrol maar noemt niet letterlijk dit drietrapspad.*
+<details><summary>1x NOT_FOUND + 2x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Het DMARC-implementatiepad wordt niet beschreven in de brontekst.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *RFC 6376 gaat over DKIM, niet over DMARC. DMARC-beleid (p=none, p=quarantine, p=reject) wordt niet behandeld in deze bron.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *DMARC wordt niet behandeld in RFC 7208.*
+</details>
+
+### `inet-mail-0018` — SKILL.md:204 *(§ 4. STARTTLS)*
+
+> Internet.nl test of MX-servers STARTTLS ondersteunen.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** STARTTLS / internet.nl testcriteria
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  > STARTTLS and DANE : secure mail server connection?
+  - *De brontekst bevestigt dat STARTTLS getest wordt, maar geeft geen detail dat dit specifiek MX-servers betreft of wat exact getest wordt.*
+<details><summary>3x OUT_OF_SCOPE (klap uit)</summary>
+
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *De bron is RFC 7489 (DMARC). STARTTLS en internet.nl testcriteria worden niet behandeld in deze bron.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *RFC 6376 gaat over DKIM-signatures, niet over internet.nl testcriteria voor STARTTLS.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *De bron is RFC 7208 over SPF. STARTTLS en internet.nl testcriteria komen niet voor in deze bron.*
+</details>
+
+### `inet-mail-0036` — reference.md:141 *(§ Waarom roteren?)*
 
 > DKIM key rotation wordt aanbevolen elke 6-12 maanden en vereist een nieuwe selector bij elke rotatie.
 
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** DKIM key rotation
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** DKIM / key rotation
 
 - **PARTIALLY_SUPPORTED** (medium) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
   > Signers are ill-advised to reuse selectors for new keys. A better strategy is to assign new keys to new selectors.
-  - *De bron ondersteunt dat nieuwe sleutels een nieuwe selector vereisen, maar noemt geen aanbevolen rotatie-interval van 6-12 maanden.*
-<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+  - *De bron ondersteunt het gebruik van nieuwe selectors bij sleutelrotatie, maar noemt geen aanbevolen interval van 6-12 maanden. Dat specifieke tijdsframe is niet terug te vinden in RFC 6376.*
+<details><summary>1x NOT_FOUND + 2x OUT_OF_SCOPE (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over DKIM key rotation in de bron.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 behandelt geen DKIM key rotation aanbevelingen of intervallen.*
+  - *DKIM key rotation wordt niet beschreven in de brontekst.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 gaat over DMARC, niet over DKIM key rotation intervallen of selectorgebruik.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *De bron is RFC 7208 (SPF-protocol). DKIM key rotation valt buiten het bereik van deze specificatie.*
+  - *De bron gaat over SPF. DKIM key rotation wordt niet behandeld.*
 </details>
 
-### `inet-mail-0042` — reference.md:153 *(§ DKIM key rotation)*
+### `inet-mail-0037` — reference.md:153 *(§ Rotatieprocedure)*
 
-> Bij DKIM key rotation moet na het publiceren van het nieuwe DNS-record gewacht worden tot DNS is gepropageerd (controleer TTL) voordat OpenDKIM wordt geconfigureerd.
+> Bij DKIM key rotation moet na het publiceren van het nieuwe DNS-record worden gewacht tot de DNS is gepropageerd (controleer TTL) voordat de OpenDKIM-configuratie wordt bijgewerkt.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** DKIM key rotation procedure
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** DKIM / rotatieprocedure
 
 - **PARTIALLY_SUPPORTED** (medium) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  > if a domain wishes to change from using a public key associated with selector 'january2005' to a public key associated with selector 'february2005', it merely makes sure that both public keys are advertised in the public-key repository concurrently for the transition period during which email may be in transit prior to verification.
-  - *De bron ondersteunt het concept van gelijktijdige publicatie tijdens een transitieperiode, maar noemt niets specifieks over wachten op DNS-propagatie of het controleren van TTL voordat de configuratie wordt gewijzigd.*
-<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+  > when rotating to a new key pair, signing should immediately commence with the new private key, and the old public key should be retained for a reasonable validation interval before being removed from the key server.
+  - *De bron ondersteunt het concept van wachten met verwijderen van het oude record (retaining for a reasonable validation interval), maar noemt niets specifieks over DNS-propagatie of TTL-controle voorafgaand aan het bijwerken van OpenDKIM-configuratie.*
+<details><summary>1x NOT_FOUND + 2x OUT_OF_SCOPE (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over DKIM key rotation procedure in de bron.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 behandelt geen DKIM key rotation procedures of DNS-propagatie stappen.*
+  - *DKIM rotatieprocedure wordt niet beschreven in de brontekst.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 gaat over DMARC, niet over DKIM key rotation procedures of DNS propagatie.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *De bron is RFC 7208 (SPF-protocol). DKIM key rotation procedure valt buiten het bereik van deze specificatie.*
+  - *De bron gaat over SPF. DKIM rotatieprocedures en OpenDKIM worden niet behandeld.*
 </details>
 
-### `inet-mail-0044` — reference.md:170 *(§ DMARC-rapportage analyseren)*
+### `inet-mail-0038` — reference.md:163 *(§ Rotatieprocedure)*
+
+> Bij DKIM key rotation dient 1-2 weken gewacht te worden na activatie van de nieuwe sleutel voordat het oude DNS-record verwijderd wordt.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** DKIM / rotatieprocedure
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  > the old public key should be retained for a reasonable validation interval before being removed from the key server.
+  - *De bron ondersteunt het wachten met verwijderen van het oude record, maar noemt geen specifiek interval van 1-2 weken.*
+<details><summary>1x NOT_FOUND + 2x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *DKIM rotatieprocedure wordt niet beschreven in de brontekst.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 gaat over DMARC, niet over wachttijden bij DKIM key rotation.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *De bron gaat over SPF. DKIM key rotation en wachttijden voor DNS-record verwijdering worden niet behandeld.*
+</details>
+
+### `inet-mail-0039` — reference.md:170 *(§ Aggregaat rapporten (rua))*
 
 > DMARC-aggregaatrapporten worden dagelijks verstuurd als XML (vaak gzipped) en bevatten statistieken over alle e-mail verstuurd namens het domein.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DMARC-rapportage aggregaat
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DMARC / rapportage
 
 - **PARTIALLY_SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  > "Visibility comes in the form of daily (or more frequent) Mail Receiver-originated feedback reports that contain aggregate data on message streams relevant to the Domain Owner." en "The aggregate data MUST be an XML file that SHOULD be subjected to GZIP compression."
-  - *De bron bevestigt dagelijkse verzending en XML/gzip-formaat. De claim 'statistieken over alle e-mail verstuurd namens het domein' is deels ondersteund; de RFC zegt dat rapporten data bevatten over berichten die het domein claimen, inclusief geslaagde en mislukte authenticatie, maar spreekt niet expliciet van 'alle e-mail verstuurd namens het domein'.*
-<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+  > Visibility comes in the form of daily (or more frequent) Mail Receiver-originated feedback reports that contain aggregate data on message streams relevant to the Domain Owner. [...] The aggregate data MUST be an XML file that SHOULD be subjected to GZIP compression.
+  - *De bron bevestigt dagelijkse verzending, XML-formaat en gzip-compressie. De claim dat rapporten 'statistieken over alle e-mail verstuurd namens het domein' bevatten wordt gedeeltelijk bevestigd: de bron spreekt van 'aggregate data on message streams relevant to the Domain Owner', inclusief berichten die DMARC passeren én falen, maar de formulering 'alle e-mail verstuurd namens het domein' is iets ruimer dan wat de bron stelt.*
+<details><summary>1x NOT_FOUND + 2x OUT_OF_SCOPE (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over DMARC aggregaatrapporten in de bron.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *DMARC-rapportage (aggregaat of anders) wordt niet behandeld in RFC 6376 over DKIM.*
+  - *DMARC aggregaatrapporten worden niet beschreven in de brontekst.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De bron beschrijft DKIM signatures. DMARC-aggregaatrapporten vallen buiten de scope van RFC 6376.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *De bron is RFC 7208 (SPF-protocol). DMARC-rapportage valt buiten het bereik van deze specificatie.*
+  - *De bron gaat over SPF. DMARC-rapportage wordt niet behandeld.*
 </details>
 
-## UNGROUNDED — geen bron ondersteunt de claim (9)
+## UNGROUNDED — geen bron ondersteunt de claim (10)
 
-### `inet-mail-0025` — SKILL.md:226 *(§ 5. DANE (DNS-based Authentication of Named Entities))*
+### `inet-mail-0012` — SKILL.md:108 *(§ 2. DKIM (DomainKeys Identified Mail))*
+
+> 2048-bit RSA is de huidige operationele aanbeveling voor DKIM-sleutels (o.a. NIST, M3AAWG), niet een eis uit RFC 6376.
+
+**Type:** factual_assertion  ·  **Modaliteit:** SHOULD  ·  **Scope:** DKIM / sleutellengte
+
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *RFC 6376 noemt alleen de 1024-bit minimumeis. Er wordt geen 2048-bit aanbeveling gedaan, en NIST of M3AAWG worden niet vermeld in deze bron.*
+
+### `inet-mail-0022` — SKILL.md:226 *(§ 5. DANE (DNS-based Authentication of Named Entities))*
 
 > DANE vereist dat DNSSEC actief is op het domein.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** DANE vereisten
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** DANE / vereisten
+
+<details><summary>1x NOT_FOUND + 3x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *De eis dat DANE DNSSEC vereist wordt niet beschreven in de brontekst.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *De bron is RFC 7489 (DMARC). DANE en DNSSEC-vereisten worden slechts zijdelings aangehaald in security considerations (sectie 12.3), maar niet als vereiste voor DANE zelf.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *RFC 6376 gaat over DKIM-signatures, niet over DANE/DNSSEC-vereisten.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *De bron is RFC 7208 over SPF. DANE en DNSSEC-vereisten zijn buiten scope.*
+</details>
+
+### `inet-mail-0026` — SKILL.md:243 *(§ 5. DANE (DNS-based Authentication of Named Entities))*
+
+> DANE Certificate Usage `3` staat voor DANE-EE (End Entity) en is aanbevolen voor mail.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** DANE / TLSA-parameters
+
+<details><summary>1x NOT_FOUND + 3x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *DANE Certificate Usage types worden niet beschreven in de brontekst.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *De bron is RFC 7489 (DMARC). DANE Certificate Usage parameters worden niet behandeld.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *RFC 6376 gaat over DKIM-signatures, niet over DANE Certificate Usage parameters in TLSA-records.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *De bron is RFC 7208 over SPF. DANE Certificate Usage parameters zijn buiten scope.*
+</details>
+
+### `inet-mail-0031` — reference.md:17 *(§ STARTTLS inschakelen)*
+
+> In Postfix dient `smtpd_tls_protocols` SSL v2, SSL v3, TLS 1.0 en TLS 1.1 uit te sluiten voor inkomende verbindingen.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** STARTTLS / Postfix-configuratie
+
+<details><summary>1x NOT_FOUND + 3x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Postfix-configuratiedetails worden niet beschreven in de brontekst.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *De bron is RFC 7489 (DMARC). Postfix-configuratie voor STARTTLS wordt niet behandeld.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De bron (RFC 6376) beschrijft DKIM signatures. Postfix-configuratie voor STARTTLS/TLS-protocollen valt buiten de scope van deze RFC.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *De bron is RFC 7208 over SPF. Postfix-configuratie voor STARTTLS is buiten scope.*
+</details>
+
+### `inet-mail-0032` — reference.md:23 *(§ STARTTLS inschakelen)*
+
+> In Postfix dient `smtp_tls_security_level = dane` ingesteld te worden voor uitgaande DANE-ondersteuning.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** DANE / Postfix-configuratie
+
+<details><summary>1x NOT_FOUND + 3x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Postfix-configuratiedetails worden niet beschreven in de brontekst.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *De bron is RFC 7489 (DMARC). Postfix-configuratie voor DANE wordt niet behandeld.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De bron beschrijft DKIM signatures. Postfix DANE-configuratie valt buiten de scope van RFC 6376.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *De bron is RFC 7208 over SPF. Postfix-configuratie voor DANE is buiten scope.*
+</details>
+
+### `inet-mail-0033` — reference.md:27 *(§ STARTTLS inschakelen)*
+
+> In Postfix dient `smtp_dns_support_level = dnssec` ingesteld te worden voor DANE-ondersteuning.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** DANE / Postfix-configuratie
+
+<details><summary>1x NOT_FOUND + 3x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Postfix-configuratiedetails worden niet beschreven in de brontekst.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 gaat over DMARC, niet over DANE of Postfix-configuratie.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De bron beschrijft DKIM signatures. Postfix DNSSEC-configuratie voor DANE valt buiten de scope van RFC 6376.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *De bron is RFC 7208 over SPF. DANE en Postfix-configuratie worden niet behandeld.*
+</details>
+
+### `inet-mail-0034` — reference.md:95 *(§ SPF voor Microsoft 365)*
+
+> Voor Microsoft 365 wordt het SPF-record `v=spf1 include:spf.protection.outlook.com -all` aanbevolen.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** SPF / Microsoft 365
 
 <details><summary>2x NOT_FOUND + 2x OUT_OF_SCOPE (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over DANE-vereisten in de bron.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 beschrijft DMARC, niet DANE-vereisten. DNSSEC wordt aanbevolen voor DMARC maar DANE-specifieke vereisten worden niet besproken.*
+  - *Microsoft 365 SPF-aanbevelingen worden niet beschreven in de brontekst.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 gaat over DMARC, niet over SPF-records voor Microsoft 365.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *De bron is RFC 6376 over DKIM. DANE-vereisten worden niet behandeld.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *RFC 7208 gaat over SPF, niet over DANE/DNSSEC-vereisten.*
+  - *De bron beschrijft DKIM signatures. SPF-records voor Microsoft 365 vallen buiten de scope van RFC 6376.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *De bron behandelt SPF in het algemeen maar noemt geen specifieke records voor Microsoft 365 of spf.protection.outlook.com.*
 </details>
 
-### `inet-mail-0029` — SKILL.md:242 *(§ 5. DANE (DNS-based Authentication of Named Entities))*
+### `inet-mail-0035` — reference.md:122 *(§ SPF voor Google Workspace)*
 
-> De aanbevolen TLSA-parameters voor mail zijn: Certificate Usage 3 (DANE-EE), Selector 1 (SubjectPublicKeyInfo), Matching Type 1 (SHA-256).
+> Voor Google Workspace wordt het SPF-record `v=spf1 include:_spf.google.com -all` aanbevolen.
 
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** DANE TLSA-parameters voor mail
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** SPF / Google Workspace
 
 <details><summary>2x NOT_FOUND + 2x OUT_OF_SCOPE (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over aanbevolen TLSA-parameters in de bron.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 beschrijft DMARC, niet DANE TLSA-parameters (Certificate Usage, Selector, Matching Type).*
+  - *Google Workspace SPF-aanbevelingen worden niet beschreven in de brontekst.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 gaat over DMARC, niet over SPF-records voor Google Workspace.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *De bron is RFC 6376 over DKIM. DANE TLSA-parameters voor mail worden niet behandeld.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *RFC 7208 gaat over SPF, niet over aanbevolen TLSA-parameters.*
+  - *De bron beschrijft DKIM signatures. SPF-records voor Google Workspace vallen buiten de scope van RFC 6376.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *De bron behandelt SPF in het algemeen maar noemt geen specifieke records voor Google Workspace of _spf.google.com.*
 </details>
 
-### `inet-mail-0031` — SKILL.md:280 *(§ Veelvoorkomende problemen)*
+### `inet-mail-0042` — reference.md:240 *(§ TLSA bijwerken bij certificaatvernieuwing)*
 
-> DMARC `p=none` is onvoldoende; overheidsorganisaties moeten overschakelen naar `p=quarantine` of `p=reject`.
+> Bij certificaatvernieuwing met DANE dient de pre-publish methode gebruikt te worden: publiceer het TLSA-record van het nieuwe certificaat voordat het actief wordt.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** DMARC veelvoorkomende problemen
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** DANE / TLSA-beheer bij certificaatvernieuwing
 
-<details><summary>3x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over DMARC p=none voor overheidsorganisaties in de bron.*
-- **NOT_FOUND** (medium) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 beschrijft p=none als een geldig beleid ('The Domain Owner requests no specific action be taken regarding delivery of messages') maar bevat geen normatieve uitspraak dat overheidsorganisaties MOETEN overschakelen naar quarantine of reject. De modality MUST is niet terug te vinden in deze bron.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *Deze bron gaat over DKIM (RFC 6376), niet over DMARC. DMARC-beleid (p=none/quarantine/reject) wordt niet behandeld.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *RFC 7208 gaat over SPF, niet over DMARC-beleid of overheidsverplichtingen.*
-</details>
-
-### `inet-mail-0033` — reference.md:17 *(§ STARTTLS inschakelen)*
-
-> Postfix `smtpd_tls_protocols` moet SSLv2, SSLv3, TLSv1 en TLSv1.1 uitsluiten voor inkomende verbindingen.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Postfix STARTTLS configuratie
-
-<details><summary>3x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+<details><summary>1x NOT_FOUND + 3x OUT_OF_SCOPE (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over Postfix-configuratie in de bron.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 gaat over DMARC als protocol, niet over Postfix-configuratie of TLS-protocollen.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *Postfix-configuratie en TLS-protocollen vallen buiten de scope van RFC 6376.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *De bron is RFC 7208 (SPF-protocol). Postfix TLS-configuratie valt buiten het bereik van deze specificatie.*
-</details>
-
-### `inet-mail-0035` — reference.md:27 *(§ STARTTLS inschakelen)*
-
-> Postfix `smtp_dns_support_level = dnssec` is vereist voor DANE-ondersteuning bij uitgaande verbindingen.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Postfix DANE configuratie
-
-<details><summary>3x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over Postfix DNSSEC-configuratie in de bron.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 behandelt geen Postfix-configuratie of DNSSEC-instellingen voor DANE.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *Postfix DNSSEC-configuratie valt buiten de scope van RFC 6376.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *De bron is RFC 7208 (SPF-protocol). Postfix DANE-configuratie valt buiten het bereik van deze specificatie.*
-</details>
-
-### `inet-mail-0040` — reference.md:129 *(§ Google Workspace)*
-
-> Google Workspace raadt een DKIM-sleutellengte van 2048-bit aan bij het genereren van een nieuw record.
-
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** Google Workspace DKIM-configuratie
-
-<details><summary>3x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over Google Workspace DKIM-sleutellengte in de bron.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 behandelt geen Google Workspace DKIM-sleutellengte aanbevelingen.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *Google Workspace-specifieke aanbevelingen voor sleutellengte worden niet behandeld. RFC 6376 noemt wel sleutelgroottes maar niet in Google Workspace-context.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *De bron is RFC 7208 (SPF-protocol). Google Workspace DKIM-sleutellengte valt buiten het bereik van deze specificatie.*
-</details>
-
-### `inet-mail-0043` — reference.md:163 *(§ DKIM key rotation)*
-
-> Bij DKIM key rotation moet het oude DNS-record pas na 1-2 weken worden verwijderd.
-
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** DKIM key rotation procedure
-
-<details><summary>3x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over verwijderen van oude DKIM DNS-records in de bron.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 behandelt geen DKIM key rotation procedures of timing voor verwijdering van oude records.*
-- **NOT_FOUND** (medium) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *RFC 6376 beschrijft een transitieperiode waarbij beide sleutels gelijktijdig beschikbaar zijn, maar noemt geen specifieke termijn van 1-2 weken voor het verwijderen van het oude record.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *De bron is RFC 7208 (SPF-protocol). DKIM key rotation timing valt buiten het bereik van deze specificatie.*
-</details>
-
-### `inet-mail-0047` — reference.md:240 *(§ TLSA bijwerken bij certificaatvernieuwing)*
-
-> Bij DANE certificaatvernieuwing moet de pre-publish methode worden gebruikt: publiceer het TLSA-record van het nieuwe certificaat voordat het actief wordt.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** DANE TLSA certificaatvernieuwing
-
-<details><summary>2x NOT_FOUND + 2x OUT_OF_SCOPE (klap uit)</summary>
-
-- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over pre-publish methode voor DANE in de bron.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 behandelt geen DANE certificaatvernieuwing of pre-publish methodes.*
+  - *De pre-publish methode voor DANE bij certificaatvernieuwing wordt niet beschreven in de brontekst.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 gaat over DMARC, niet over DANE pre-publish methodes bij certificaatvernieuwing.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *RFC 6376 gaat over DKIM-handtekeningen, niet over DANE of de pre-publish methode voor TLSA-records.*
+  - *De bron beschrijft DKIM signatures. DANE pre-publish methode bij certificaatvernieuwing valt buiten de scope van RFC 6376.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *De bron is RFC 7208 (SPF-protocol). DANE pre-publish methode valt buiten het bereik van deze specificatie.*
+  - *De bron gaat over SPF. DANE pre-publish methode voor certificaatvernieuwing wordt niet behandeld.*
 </details>
 
-### `inet-mail-0049` — reference.md:267 *(§ MTA-STS configuratie)*
+### `inet-mail-0044` — reference.md:267 *(§ Vereisten)*
 
 > MTA-STS vereist een DNS TXT-record op `_mta-sts.example.nl`, een HTTPS-website op `mta-sts.example.nl` met geldig certificaat, en een beleidsbestand op `https://mta-sts.example.nl/.well-known/mta-sts.txt`.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** MTA-STS vereisten
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** MTA-STS / vereisten
 
-<details><summary>3x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+<details><summary>1x NOT_FOUND + 3x OUT_OF_SCOPE (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over MTA-STS vereisten in de bron.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 gaat over DMARC, niet over MTA-STS. Geen enkel onderdeel van de MTA-STS vereisten (DNS TXT-record op _mta-sts, HTTPS-website, beleidsbestand) wordt behandeld.*
+  - *MTA-STS vereisten worden niet beschreven in de brontekst.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 gaat over DMARC, niet over MTA-STS vereisten.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *RFC 6376 gaat over DKIM-handtekeningen, niet over MTA-STS-vereisten zoals DNS TXT-records of beleidsbestanden.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *RFC 7208 behandelt uitsluitend SPF. MTA-STS, DNS TXT-records op _mta-sts, en bijbehorende HTTPS-vereisten komen niet voor in de brontekst.*
+  - *De bron beschrijft DKIM signatures. MTA-STS vereisten vallen buiten de scope van RFC 6376.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *De bron gaat over SPF. MTA-STS vereisten worden niet behandeld.*
 </details>
 
 ## GROUNDED — minstens één bron ondersteunt de claim (8)
@@ -791,128 +698,145 @@
 <details>
 <summary>Klap uit voor alle GROUNDED claims</summary>
 
-### `inet-mail-0001` — SKILL.md:26 *(§ Overzicht)*
+### `inet-mail-0002` — SKILL.md:54 *(§ 1. SPF (Sender Policy Framework))*
 
-> Internet.nl test e-maildomeinen op SPF, DKIM, DMARC, STARTTLS en DANE.
+> Internet.nl test of een SPF-record aanwezig is als DNS TXT-record.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl mailtest
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** SPF / internet.nl testcriteria
 
-- **SUPPORTED** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  > After you enter a domain name of an email service, we will test if the email service offers support for the modern Internet Standards below. [...] DMARC, DKIM and SPF : authenticity marks against email phishing? STARTTLS and DANE : secure mail server connection?
-- **PARTIALLY_SUPPORTED** (medium) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  > DMARC is a scalable mechanism by which a mail-originating organization can express domain-level policies and preferences for message validation, disposition, and reporting... The following mechanisms for determining Authenticated Identifiers are supported in this version of DMARC: [DKIM]... [SPF]
-  - *RFC 7489 behandelt alleen DMARC (en de relatie met SPF en DKIM). STARTTLS en DANE worden in deze bron niet vermeld. De claim over internet.nl als testplatform wordt ook niet bevestigd.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *De bron is RFC 6376 (DKIM specificatie). Internet.nl's testscope (SPF, DKIM, DMARC, STARTTLS, DANE) wordt hier niet behandeld.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *De bron is RFC 7208, de SPF-specificatie. Internet.nl wordt niet genoemd; DKIM, DMARC, STARTTLS en DANE vallen buiten scope van deze bron.*
-
-### `inet-mail-0003` — SKILL.md:50 *(§ 1. SPF (Sender Policy Framework))*
-
-> SPF specificeert welke mailservers e-mail mogen versturen namens een domein via een DNS TXT-record.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** SPF (Sender Policy Framework)
-
-- **SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  > [SPF], which can authenticate both the domain found in an [SMTP] HELO/EHLO command (the HELO identity) and the domain found in an SMTP MAIL command (the MAIL FROM identity)... Domain Owner constructs an SPF policy and publishes it in its DNS database as per [SPF].
-  - *De bron bevestigt dat SPF via DNS gepubliceerd wordt en aangeeft welke mailservers mogen versturen namens een domein. Het DNS TXT-record formaat wordt impliciet bevestigd via de verwijzing naar SPF-publicatie in DNS.*
 - **SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  > SPF-compliant domain publishes valid SPF records as described in Section 3. These records authorize the use of the relevant domain names in the "HELO" and "MAIL FROM" identities by the MTAs specified therein. [...] SPF records MUST be published as a DNS TXT (type 16) Resource Record (RR)
+  > SPF records MUST be published as a DNS TXT (type 16) Resource Record (RR) [RFC1035] only.
+  - *De bron bevestigt dat SPF-records als DNS TXT-record gepubliceerd moeten worden. Internet.nl-specifieke testcriteria staan niet in de bron, maar de technische basis voor de claim wordt volledig ondersteund.*
+<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
 - **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *De bron noemt SPF enkel als categorie, maar geeft geen technische beschrijving van hoe SPF werkt.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *De bron gaat over DKIM, niet over SPF (Sender Policy Framework). SPF wordt in RFC 6376 niet gedefinieerd of beschreven.*
+  - *De brontekst vermeldt SPF als onderdeel van de test maar geeft geen detail over DNS TXT-record controle.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *De claim gaat over internet.nl testcriteria voor SPF. De bron is de DMARC RFC, niet een SPF-specificatie of internet.nl documentatie.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De bron gaat over DKIM, niet over SPF of internet.nl testcriteria.*
+</details>
 
-### `inet-mail-0008` — SKILL.md:99 *(§ 2. DKIM (DomainKeys Identified Mail))*
+### `inet-mail-0003` — SKILL.md:55 *(§ 1. SPF (Sender Policy Framework))*
 
-> DKIM voorziet e-mail van een cryptografische handtekening via een DNS-publicsleutel die de ontvangende mailserver verifieert.
+> Internet.nl test of het SPF-record een correcte syntax heeft.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DKIM (DomainKeys Identified Mail)
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** SPF / internet.nl testcriteria
 
-- **SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  > [DKIM], which provides a domain-level identifier in the content of the 'd=' tag of a validated DKIM-Signature header field... Submission service passes relevant details to the DKIM signing module in order to generate a DKIM signature to be applied to the message.
-  - *De bron bevestigt dat DKIM een cryptografische handtekening toevoegt via een DNS-gepubliceerde sleutel die de ontvangende mailserver verifieert.*
-- **SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  > DKIM permits a person, role, or organization that owns the signing domain to claim some responsibility for a message by associating the domain with the message. Assertion of responsibility is validated through a cryptographic signature and by querying the Signer's domain directly to retrieve the appropriate public key.
+- **SUPPORTED** (medium) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  > The check_host() function parses and interprets the SPF record to find a result for the current test. The syntax of the record is validated first, and if there are any syntax errors anywhere in the record, check_host() returns immediately with the result "permerror"
+  - *De bron bevestigt dat syntaxvalidatie onderdeel is van SPF-verwerking. De specifieke internetl.nl-testlogica staat niet in de bron, maar de technische grondslag voor syntaxcontrole is aanwezig.*
+<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
 - **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *De bron noemt DKIM enkel als categorie zonder technische beschrijving.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *DKIM wordt niet behandeld in RFC 7208; dit is een SPF-specificatie.*
+  - *Syntaxcontrole van SPF-records wordt niet beschreven in de brontekst.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *De claim gaat over internet.nl testcriteria voor SPF-syntaxvalidatie. De bron is de DMARC RFC.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De bron gaat over DKIM, niet over SPF of internet.nl testcriteria.*
+</details>
 
-### `inet-mail-0012` — SKILL.md:107 *(§ 2. DKIM (DomainKeys Identified Mail))*
+### `inet-mail-0004` — SKILL.md:56 *(§ 1. SPF (Sender Policy Framework))*
+
+> Internet.nl test of het SPF-record maximaal 10 DNS-lookups bevat (include, a, mx, redirect).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** SPF / internet.nl testcriteria
+
+- **SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  > SPF implementations MUST limit the total number of those terms to 10 during SPF evaluation, to avoid unreasonable load on the DNS. If this limit is exceeded, the implementation MUST return "permerror". The following terms cause DNS queries: the "include", "a", "mx", "ptr", and "exists" mechanisms, and the "redirect" modifier.
+  - *De bron bevestigt de limiet van 10 DNS-lookups en noemt include, a, mx en redirect expliciet als lookup-veroorzakers. De claim vermeldt niet 'ptr' en 'exists', maar dat is geen tegenspraak.*
+<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *De brontekst bevat geen informatie over het testen van DNS-lookup limieten in SPF.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *De claim gaat over internet.nl testcriteria voor SPF DNS-lookups. De bron is de DMARC RFC.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De bron gaat over DKIM, niet over SPF of internet.nl testcriteria.*
+</details>
+
+### `inet-mail-0007` — SKILL.md:75 *(§ 1. SPF (Sender Policy Framework))*
+
+> Het SPF-mechanisme `redirect=domein` gebruikt het SPF-record van een ander domein.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** SPF mechanismen
+
+- **SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  > The "redirect" modifier is intended for consolidating both authorizations and policy into a common set to be shared within a single ADMD... If all mechanisms fail to match, and a "redirect" modifier is present, then processing proceeds as follows: The <domain-spec> portion of the redirect section is expanded... Then check_host() is evaluated with the resulting string as the <domain>.
+  - *De bron bevestigt dat redirect het SPF-record van een ander domein gebruikt voor verdere evaluatie.*
+<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *SPF redirect-mechanisme wordt niet beschreven in de brontekst.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *De claim gaat over het SPF `redirect=`-mechanisme. De bron is de DMARC RFC, niet de SPF-specificatie.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De bron gaat over DKIM, niet over SPF-mechanismen.*
+</details>
+
+### `inet-mail-0011` — SKILL.md:108 *(§ 2. DKIM (DomainKeys Identified Mail))*
 
 > RFC 6376 vereist minimaal 1024-bit RSA voor langlevende DKIM-sleutels.
 
-**Type:** reference_claim  ·  **Modaliteit:** MUST  ·  **Scope:** DKIM RFC 6376
+**Type:** reference_claim  ·  **Modaliteit:** MUST  ·  **Scope:** DKIM / RFC 6376
 
 - **SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
   > Signers MUST use RSA keys of at least 1024 bits for long-lived keys. Verifiers MUST be able to validate signatures with keys ranging from 512 bits to 2048 bits, and they MAY be able to validate signatures with larger keys.
 
-### `inet-mail-0013` — SKILL.md:108 *(§ 2. DKIM (DomainKeys Identified Mail))*
+### `inet-mail-0013` — SKILL.md:150 *(§ 3. DMARC (Domain-based Message Authentication, Reporting and Conformance))*
 
-> 2048-bit RSA is de huidige operationele aanbeveling voor DKIM-sleutels (o.a. NIST, M3AAWG), niet een eis uit RFC 6376.
+> Internet.nl test of een DMARC-record aanwezig is op `_dmarc.example.nl`.
 
-**Type:** factual_assertion  ·  **Modaliteit:** SHOULD  ·  **Scope:** DKIM sleutellengte aanbeveling
-
-- **SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  > Signers MUST use RSA keys of at least 1024 bits for long-lived keys.
-  - *RFC 6376 schrijft alleen 1024-bit als minimum voor. De claim dat 2048-bit een aanbeveling is van NIST/M3AAWG en níet een eis uit RFC 6376 is correct: de bron noemt geen 2048-bit eis of aanbeveling, alleen een minimum van 1024-bit.*
-
-### `inet-mail-0014` — SKILL.md:150 *(§ 3. DMARC (Domain-based Message Authentication, Reporting and Conformance))*
-
-> Het DMARC-record staat op `_dmarc.example.nl` als DNS TXT-record.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DMARC DNS-record
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DMARC / internet.nl testcriteria
 
 - **SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  > Domain Owner DMARC preferences are stored as DNS TXT records in subdomains named '_dmarc'. For example, the Domain Owner of 'example.com' would post DMARC preferences in a TXT record at '_dmarc.example.com'.
-  - *De bron bevestigt exact dit patroon, met 'example.com' als voorbeeld. De claim gebruikt 'example.nl' maar het principe is identiek.*
+  > Domain Owner DMARC preferences are stored as DNS TXT records in subdomains named "_dmarc". For example, the Domain Owner of "example.com" would post DMARC preferences in a TXT record at "_dmarc.example.com".
+  - *De bron bevestigt dat DMARC-records worden gepubliceerd als DNS TXT-records op `_dmarc.<domein>`. De claim verwijst naar `_dmarc.example.nl` in plaats van `_dmarc.example.com`, maar dit is slechts een ander TLD-voorbeeld; het principe is identiek.*
 <details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *De bron geeft geen technische details over DMARC DNS-records.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *De claim gaat over DMARC DNS-records (_dmarc.example.nl). RFC 6376 gaat over DKIM; DMARC wordt niet behandeld.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *De specifieke DMARC-testcriteria, inclusief het `_dmarc`-subdomein, worden niet beschreven in de brontekst.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De bron gaat over DKIM, niet over DMARC of internet.nl testcriteria.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
   - *DMARC wordt niet behandeld in RFC 7208.*
 </details>
 
-### `inet-mail-0017` — SKILL.md:154 *(§ 3. DMARC (Domain-based Message Authentication, Reporting and Conformance))*
+### `inet-mail-0017` — SKILL.md:174 *(§ 3. DMARC (Domain-based Message Authentication, Reporting and Conformance))*
 
-> DMARC implementatiepad: start met `p=none` om rapportages te verzamelen, schakel daarna over naar `quarantine` en uiteindelijk `reject`.
+> De DMARC-tag `pct` geeft het percentage berichten aan waarop het beleid wordt toegepast (0-100).
 
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** DMARC gefaseerde uitrol
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DMARC / DNS-record parameters
 
 - **SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  > The owner of the domain 'example.com' has deployed SPF and DKIM on its messaging infrastructure. The owner wishes to begin using DMARC with a policy that will solicit aggregate feedback from receivers without affecting how the messages are processed... ('p=none')... The Domain Owner accomplishes this by constructing a policy record... Receivers should quarantine messages from this Organizationa...
-  - *De bron illustreert expliciet het gefaseerde implementatiepad: beginnen met p=none voor rapportages, dan quarantine, en de reject-optie wordt ook beschreven als eindstadium.*
-<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+  > pct: (plain-text integer between 0 and 100, inclusive; OPTIONAL; default is 100). Percentage of messages from the Domain Owner's mail stream to which the DMARC policy is to be applied.
+<details><summary>1x NOT_FOUND + 2x OUT_OF_SCOPE (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen implementatieadvies of fasering voor DMARC in de bron.*
+  - *DMARC-tags zoals `pct` worden niet beschreven in de brontekst.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *De bron is RFC 6376 over DKIM. DMARC-implementatiepad wordt niet behandeld.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
-  - *DMARC-implementatieadvies valt buiten scope van RFC 7208.*
+  - *RFC 6376 gaat over DKIM, niet over DMARC. De DMARC-tag `pct` wordt niet behandeld in deze bron.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *DMARC wordt niet behandeld in RFC 7208.*
 </details>
 
-### `inet-mail-0030` — SKILL.md:278 *(§ Veelvoorkomende problemen)*
+### `inet-mail-0029` — SKILL.md:278 *(§ Veelvoorkomende problemen)*
 
-> Een SPF `permerror` wordt veroorzaakt door meer dan 10 DNS-lookups; oplossing is minder `include`-verwijzingen en direct gebruik van `ip4`/`ip6`.
+> Een SPF `permerror` wordt veroorzaakt door meer dan 10 DNS-lookups; oplossing is het verminderen van `include`-verwijzingen of direct gebruik van `ip4`/`ip6`.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** SPF veelvoorkomende problemen
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** SPF / veelvoorkomende problemen
 
 - **SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
   > SPF implementations MUST limit the total number of those terms to 10 during SPF evaluation, to avoid unreasonable load on the DNS. If this limit is exceeded, the implementation MUST return "permerror".
-  - *De bron bevestigt dat overschrijding van 10 DNS-lookups een permerror oplevert. De oplossingsrichting (minder includes, direct ip4/ip6) wordt impliciet ondersteund door Section 10.1.1 die ip4/ip6 als 'Best record' aanbeveelt.*
-<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+  - *De bron bevestigt dat meer dan 10 DNS-lookups leidt tot permerror. De oplossingsrichting (minder include of ip4/ip6 gebruiken) wordt indirect ondersteund door Section 10.1.1 die ip4/ip6 als 'Best record' aanbeveelt boven mx of include.*
+<details><summary>1x NOT_FOUND + 2x OUT_OF_SCOPE (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
-  - *Geen informatie over SPF permerror of DNS-lookup problemen in de bron.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
-  - *RFC 7489 beschrijft DMARC. SPF permerror door meer dan 10 DNS-lookups wordt niet behandeld in deze bron.*
+  - *SPF permerror en oplossingen worden niet beschreven in de brontekst.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *De bron is RFC 7489 (DMARC). SPF DNS-lookup limieten en permerror worden niet behandeld in deze bron.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
-  - *De bron is RFC 6376 over DKIM. SPF en DNS-lookup limieten worden niet behandeld.*
+  - *RFC 6376 gaat over DKIM-signatures, niet over SPF permerror of DNS-lookup limieten.*
 </details>
 
 </details>

--- a/skills/inet-mail/audit.md
+++ b/skills/inet-mail/audit.md
@@ -1,0 +1,918 @@
+<!-- markdownlint-disable MD052 MD034 MD013 -->
+# Audit inet-mail — 2026-05-17
+
+> Automatisch gegenereerd door audit-tooling. Niet handmatig bewerken; wijzig SKILL.md / reference.md en regenereer.
+
+## Samenvatting
+
+| Status | Aantal | % |
+|--------|--------|---|
+| UNSUPPORTED_ASSERTION | 27 | 54% |
+| CONTRADICTED | 0 | 0% |
+| PARTIALLY_GROUNDED | 6 | 12% |
+| UNGROUNDED | 9 | 18% |
+| NO_SOURCE | 0 | 0% |
+| UNVERIFIABLE | 0 | 0% |
+| KNOWN_DISCREPANCY | 0 | 0% |
+| GROUNDED | 8 | 16% |
+
+*Geverifieerd met sonnet, 13 calls, $3.1525.*
+
+## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (27)
+
+### `inet-mail-0002` — SKILL.md:27 *(§ Overzicht)*
+
+> SPF, DKIM en DMARC staan op de pas-toe-of-leg-uit-lijst van Forum Standaardisatie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie open standaarden
+
+<details><summary>3x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *De bron vermeldt niets over Forum Standaardisatie of de pas-toe-of-leg-uit-lijst.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 bevat geen informatie over de pas-toe-of-leg-uit-lijst van Forum Standaardisatie.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De bron is RFC 6376. De pas-toe-of-leg-uit-lijst van Forum Standaardisatie is een Nederlandse beleidsaangelegenheid die buiten scope van deze RFC valt.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *RFC 7208 behandelt geen Forum Standaardisatie of pas-toe-of-leg-uit-lijst.*
+</details>
+
+### `inet-mail-0004` — SKILL.md:54 *(§ 1. SPF (Sender Policy Framework))*
+
+> Internet.nl controleert of een SPF-record aanwezig is als DNS TXT-record.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl SPF-test
+
+<details><summary>2x NOT_FOUND + 2x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *De bron noemt SPF maar beschrijft geen specifieke subtests.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 beschrijft DMARC, niet de specifieke werking van internet.nl als testplatform.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *Gaat over internet.nl SPF-test. De bron beschrijft DKIM, niet SPF of internet.nl.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *De bron beschrijft de SPF-standaard zelf, niet wat internet.nl controleert. De bron bevestigt wel dat SPF als DNS TXT-record gepubliceerd moet worden.*
+</details>
+
+### `inet-mail-0005` — SKILL.md:55 *(§ 1. SPF (Sender Policy Framework))*
+
+> Internet.nl controleert de correcte syntax van SPF-records.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl SPF-test
+
+<details><summary>2x NOT_FOUND + 2x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over syntax-controle van SPF-records in de bron.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 beschrijft DMARC, niet de specifieke syntaxcontroles van internet.nl.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *Gaat over internet.nl SPF-syntaxcontrole. Buiten scope van RFC 6376.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *De bron beschrijft SPF-syntaxregels uitgebreid, maar zegt niets over wat internet.nl controleert.*
+</details>
+
+### `inet-mail-0007` — SKILL.md:57 *(§ 1. SPF (Sender Policy Framework))*
+
+> Internet.nl controleert of het SPF-record eindigt op `-all` (fail) of `~all` (softfail).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl SPF-test
+
+<details><summary>2x NOT_FOUND + 2x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over -all of ~all controle in de bron.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 beschrijft DMARC, niet de specifieke internet.nl-controle op `-all` of `~all`. Wel wordt SPF-beleid algemeen benoemd, maar de claim over internet.nl-testcriteria is buiten scope van deze bron.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *Gaat over SPF -all / ~all mechanisme. Buiten scope van RFC 6376.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *Wat internet.nl controleert valt buiten RFC 7208. De bron bespreekt wel -all en ~all als geldige qualifiers (fail resp. softfail), maar zegt niets over internet.nl-testcriteria.*
+</details>
+
+### `inet-mail-0009` — SKILL.md:103 *(§ 2. DKIM (DomainKeys Identified Mail))*
+
+> Internet.nl test of minimaal 1 geldige DKIM-handtekening aanwezig is op de testmail.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl DKIM-test
+
+<details><summary>3x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over specifieke DKIM-subtests in de bron.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 beschrijft DMARC, niet de specifieke werking van internet.nl als testplatform.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De claim gaat over internet.nl's testgedrag. RFC 6376 beschrijft het protocol, niet hoe internet.nl test.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *DKIM en internet.nl vallen buiten scope van RFC 7208.*
+</details>
+
+### `inet-mail-0011` — SKILL.md:106 *(§ 2. DKIM (DomainKeys Identified Mail))*
+
+> Internet.nl controleert alleen of een DKIM-record bestaat; de sleutellengte wordt niet getest.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl DKIM-test
+
+<details><summary>3x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over sleutellengte-controle of het ontbreken daarvan in de bron.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 beschrijft DMARC, niet de specifieke internet.nl-testcriteria voor sleutellengte.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De claim gaat over wat internet.nl wel of niet controleert. RFC 6376 beschrijft het protocol, niet de testmethodologie van internet.nl.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *DKIM en internet.nl vallen buiten scope van RFC 7208.*
+</details>
+
+### `inet-mail-0015` — SKILL.md:151 *(§ 3. DMARC (Domain-based Message Authentication, Reporting and Conformance))*
+
+> Internet.nl test of het DMARC-beleid `quarantine` of `reject` is; `none` is onvoldoende voor productie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl DMARC-test
+
+<details><summary>3x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over specifieke DMARC-beleidscontroles in de bron.*
+- **NOT_FOUND** (medium) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 beschrijft de DMARC-beleidsopties (none, quarantine, reject) maar bevat geen uitspraak over wat internet.nl als 'voldoende voor productie' beschouwt. De bron beschrijft wel dat 'p=none' geen actie verzoekt, maar dat is een andere claim dan wat internet.nl beoordeelt.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De claim gaat over internet.nl DMARC-testen en DMARC-beleid (quarantine/reject). RFC 6376 behandelt DMARC niet.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *DMARC en internet.nl vallen buiten scope van RFC 7208.*
+</details>
+
+### `inet-mail-0016` — SKILL.md:152 *(§ 3. DMARC (Domain-based Message Authentication, Reporting and Conformance))*
+
+> Internet.nl test of een DMARC rapportage-adres (rua) geconfigureerd is.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl DMARC-test
+
+<details><summary>3x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over rua-rapportageadres check in de bron.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 beschrijft DMARC inclusief de rua-tag, maar bevat geen uitspraak over wat internet.nl test.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De bron is RFC 6376 over DKIM. DMARC wordt niet behandeld in deze RFC.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *DMARC en internet.nl vallen buiten scope van RFC 7208.*
+</details>
+
+### `inet-mail-0018` — SKILL.md:156 *(§ 3. DMARC (Domain-based Message Authentication, Reporting and Conformance))*
+
+> Internet.nl scoort alleen DMARC-beleid `quarantine` of `reject` als voldoende.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl DMARC-test
+
+<details><summary>2x NOT_FOUND + 2x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over scoren van DMARC-beleid in de bron.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 beschrijft DMARC-beleid (none, quarantine, reject) maar bevat geen informatie over internet.nl scoringscriteria of wat als 'voldoende' wordt beschouwd.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De bron is RFC 6376 over DKIM. Internet.nl DMARC-scoring wordt niet behandeld.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *De bron is RFC 7208 over SPF. DMARC en internet.nl scoringslogica komen niet voor in deze spec.*
+</details>
+
+### `inet-mail-0019` — SKILL.md:201 *(§ 4. STARTTLS)*
+
+> STARTTLS versleutelt SMTP-verkeer tussen mailservers.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** STARTTLS
+
+<details><summary>2x NOT_FOUND + 2x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *De bron noemt STARTTLS maar geeft geen technische beschrijving van de werking.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 gaat over DMARC. STARTTLS wordt niet besproken in deze bron.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De bron is RFC 6376 over DKIM. STARTTLS wordt niet behandeld.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *RFC 7208 gaat over SPF, niet over STARTTLS.*
+</details>
+
+### `inet-mail-0020` — SKILL.md:204 *(§ 4. STARTTLS)*
+
+> Internet.nl test of MX-servers STARTTLS ondersteunen.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl STARTTLS-test
+
+<details><summary>1x NOT_FOUND + 3x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over specifieke STARTTLS-subtests in de bron.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 beschrijft DMARC, niet internet.nl testmethodologie of STARTTLS-tests.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De bron is RFC 6376 over DKIM. Internet.nl STARTTLS-tests worden niet behandeld.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *RFC 7208 gaat over SPF, niet over internet.nl STARTTLS-tests.*
+</details>
+
+### `inet-mail-0021` — SKILL.md:205 *(§ 4. STARTTLS)*
+
+> Internet.nl test of MX-servers TLS 1.2 of hoger ondersteunen; TLS 1.0/1.1 geeft een phase-out waarschuwing; SSL 2.0/3.0 is een harde fout.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl STARTTLS-test TLS-versies
+
+<details><summary>1x NOT_FOUND + 3x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over TLS-versiecontroles in de bron.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 beschrijft DMARC, niet internet.nl TLS-versietests.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De bron is RFC 6376 over DKIM. TLS-versievereisten voor MX-servers worden niet behandeld.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *RFC 7208 gaat over SPF, niet over TLS-versievereisten of internet.nl tests.*
+</details>
+
+### `inet-mail-0022` — SKILL.md:206 *(§ 4. STARTTLS)*
+
+> Internet.nl test of MX-servers een geldig certificaat hebben voor STARTTLS.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl STARTTLS-test
+
+<details><summary>1x NOT_FOUND + 3x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over certificaatvalidatie in STARTTLS-test in de bron.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 beschrijft DMARC, niet internet.nl certificaatvalidatietests.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De bron is RFC 6376 over DKIM. Certificaatvalidatie voor STARTTLS wordt niet behandeld.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *RFC 7208 gaat over SPF, niet over certificaatvalidatie bij STARTTLS.*
+</details>
+
+### `inet-mail-0023` — SKILL.md:207 *(§ 4. STARTTLS)*
+
+> Internet.nl test of MX-servers geen terugval naar onversleuteld verkeer toestaan.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl STARTTLS-test
+
+<details><summary>1x NOT_FOUND + 3x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over downgrade-protection test in de bron.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 beschrijft DMARC, niet internet.nl downgrade-protectietests.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De bron is RFC 6376 over DKIM. Downgrade-bescherming voor STARTTLS wordt niet behandeld.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *RFC 7208 gaat over SPF, niet over downgrade-bescherming bij STARTTLS.*
+</details>
+
+### `inet-mail-0026` — SKILL.md:229 *(§ 5. DANE (DNS-based Authentication of Named Entities))*
+
+> Internet.nl test of TLSA-records aanwezig zijn voor MX-servers.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl DANE-test
+
+<details><summary>1x NOT_FOUND + 3x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over TLSA-record aanwezigheidscheck in de bron.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 beschrijft DMARC, niet internet.nl DANE-tests of TLSA-records.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De bron is RFC 6376 over DKIM. Internet.nl DANE-tests worden niet behandeld.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *RFC 7208 gaat over SPF, niet over internet.nl DANE-tests.*
+</details>
+
+### `inet-mail-0027` — SKILL.md:230 *(§ 5. DANE (DNS-based Authentication of Named Entities))*
+
+> Internet.nl test of TLSA-parameters correct zijn voor MX-servers.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl DANE-test
+
+<details><summary>1x NOT_FOUND + 3x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over TLSA-parametercontroles in de bron.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 beschrijft DMARC, niet internet.nl TLSA-parametertests.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De bron is RFC 6376 over DKIM. TLSA-parametervalidatie wordt niet behandeld.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *RFC 7208 gaat over SPF, niet over TLSA-parametervalidatie.*
+</details>
+
+### `inet-mail-0028` — SKILL.md:231 *(§ 5. DANE (DNS-based Authentication of Named Entities))*
+
+> Internet.nl test of DNSSEC actief is op het MX-domein.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl DANE-test
+
+<details><summary>1x NOT_FOUND + 3x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over DNSSEC-controle in DANE-test in de bron.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 beschrijft DMARC, niet internet.nl DNSSEC-tests voor MX-domeinen.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De bron is RFC 6376 over DKIM. DNSSEC-vereisten voor MX-domeinen worden niet behandeld.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *RFC 7208 gaat over SPF, niet over internet.nl DANE/DNSSEC-tests.*
+</details>
+
+### `inet-mail-0032` — SKILL.md:282 *(§ Veelvoorkomende problemen)*
+
+> Een DANE TLSA mismatch treedt op als het certificaat vernieuwd is zonder het TLSA-record bij te werken.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DANE veelvoorkomende problemen
+
+<details><summary>3x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over DANE TLSA mismatch in de bron.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 beschrijft DMARC, niet DANE TLSA-mismatches bij certificaatvernieuwing.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *DANE en TLSA-records worden niet behandeld in deze DKIM-specificatie.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *RFC 7208 gaat over SPF, niet over DANE TLSA mismatches bij certificaatvernieuwing.*
+</details>
+
+### `inet-mail-0034` — reference.md:23 *(§ STARTTLS inschakelen)*
+
+> Postfix `smtp_tls_security_level = dane` configureert uitgaande verbindingen om DANE te gebruiken.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Postfix DANE configuratie
+
+<details><summary>3x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over Postfix DANE-configuratie in de bron.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 behandelt geen Postfix-configuratie of DANE.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *Postfix DANE-configuratie wordt niet behandeld in deze DKIM-specificatie.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *De bron is RFC 7208 (SPF-protocol). Postfix DANE-configuratie valt buiten het bereik van deze specificatie.*
+</details>
+
+### `inet-mail-0036` — reference.md:95 *(§ Microsoft Exchange / Microsoft 365)*
+
+> SPF voor Microsoft 365 gebruikt het mechanisme `include:spf.protection.outlook.com`.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Microsoft 365 SPF-configuratie
+
+<details><summary>4x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over Microsoft 365 SPF-configuratie in de bron.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 behandelt geen Microsoft 365-specifieke SPF-configuratie.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *SPF en Microsoft 365-specifieke configuratie worden niet behandeld in RFC 6376.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *De bron beschrijft de SPF-standaard algemeen maar noemt geen Microsoft 365-specifieke include-mechanismen.*
+</details>
+
+### `inet-mail-0037` — reference.md:100 *(§ Microsoft Exchange / Microsoft 365)*
+
+> DKIM voor Microsoft 365 wordt geconfigureerd via het Microsoft 365 Defender-portaal onder Email & Collaboration > Policies > DKIM.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Microsoft 365 DKIM-configuratie
+
+<details><summary>3x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over Microsoft 365 DKIM-configuratie in de bron.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 behandelt geen Microsoft 365 Defender-portaal of DKIM-configuratie daarin.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *Microsoft 365 Defender-portaal en platform-specifieke DKIM-configuratie vallen buiten de scope van RFC 6376.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *De bron is RFC 7208 (SPF-protocol). DKIM-configuratie via Microsoft 365 Defender-portaal valt buiten het bereik van deze specificatie.*
+</details>
+
+### `inet-mail-0038` — reference.md:107 *(§ Microsoft Exchange / Microsoft 365)*
+
+> Microsoft 365 DKIM gebruikt CNAME-records die verwijzen naar `selector1-example-nl._domainkey.example.onmicrosoft.com` en `selector2-example-nl._domainkey.example.onmicrosoft.com`.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Microsoft 365 DKIM DNS-configuratie
+
+<details><summary>3x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over Microsoft 365 CNAME-records in de bron.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 bevat geen informatie over Microsoft 365 DKIM CNAME-records.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *Microsoft 365-specifieke CNAME-records worden niet behandeld in RFC 6376.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *De bron is RFC 7208 (SPF-protocol). Microsoft 365 DKIM CNAME-records vallen buiten het bereik van deze specificatie.*
+</details>
+
+### `inet-mail-0039` — reference.md:122 *(§ Google Workspace)*
+
+> SPF voor Google Workspace gebruikt het mechanisme `include:_spf.google.com`.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Google Workspace SPF-configuratie
+
+<details><summary>4x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over Google Workspace SPF-configuratie in de bron.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 behandelt geen Google Workspace SPF-configuratie.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *Google Workspace SPF-configuratie valt buiten de scope van RFC 6376.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *De bron beschrijft de SPF-standaard algemeen maar noemt geen Google Workspace-specifieke include-mechanismen.*
+</details>
+
+### `inet-mail-0045` — reference.md:215 *(§ Forensische rapporten (ruf))*
+
+> Niet alle mailproviders versturen forensische DMARC-rapporten (ruf).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DMARC forensische rapportage
+
+<details><summary>3x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over forensische DMARC-rapporten in de bron.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 beschrijft het mechanisme voor forensische rapporten (ruf-tag) maar zegt niets over of mailproviders deze al dan niet versturen in de praktijk.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *DMARC forensische rapporten (ruf) worden niet behandeld in RFC 6376 over DKIM.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *De bron is RFC 7208 (SPF-protocol). DMARC forensische rapportage valt buiten het bereik van deze specificatie.*
+</details>
+
+### `inet-mail-0046` — reference.md:241 *(§ TLSA bijwerken bij certificaatvernieuwing)*
+
+> Bij DANE met DANE-EE (3) + SPKI (1) telt alleen de publieke sleutel, niet het volledige certificaat, zodat bij hergebruik van dezelfde privesleutel het TLSA-record niet hoeft te veranderen.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DANE TLSA certificaatvernieuwing
+
+<details><summary>2x NOT_FOUND + 2x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over DANE-EE en sleutelhergebruik in de bron.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 behandelt geen DANE TLSA-records, DANE-EE of SPKI-selectors.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *RFC 6376 gaat over DKIM-handtekeningen, niet over DANE of TLSA-records. De bron bevat geen informatie over DANE-EE, SPKI-selectors of TLSA-certificaatvernieuwing.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *De bron is RFC 7208 (SPF-protocol). DANE TLSA certificaatvernieuwing valt buiten het bereik van deze specificatie.*
+</details>
+
+### `inet-mail-0048` — reference.md:262 *(§ MTA-STS configuratie)*
+
+> MTA-STS wordt niet getest door internet.nl en is een aanvullende best practice naast DANE.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** MTA-STS
+
+<details><summary>3x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over MTA-STS in de bron.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 beschrijft uitsluitend DMARC. MTA-STS wordt nergens in de brontekst genoemd.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *RFC 6376 gaat over DKIM-handtekeningen, niet over MTA-STS of internet.nl-tests.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *RFC 7208 behandelt uitsluitend SPF (Sender Policy Framework). MTA-STS wordt nergens in de brontekst genoemd.*
+</details>
+
+### `inet-mail-0050` — reference.md:291 *(§ SMTP TLS Reporting (TLSRPT))*
+
+> SMTP TLS Reporting (TLSRPT) gebruikt een DNS TXT-record op `_smtp._tls.example.nl` met formaat `v=TLSRPTv1; rua=mailto:...` om rapporten te ontvangen over TLS-fouten.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** SMTP TLS Reporting (TLSRPT)
+
+<details><summary>3x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over SMTP TLS Reporting in de bron.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *SMTP TLS Reporting (TLSRPT) wordt niet vermeld in RFC 7489. De bron behandelt uitsluitend DMARC-rapportage via rua/ruf tags.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *RFC 6376 gaat over DKIM-handtekeningen, niet over SMTP TLS Reporting (TLSRPT) of bijbehorende DNS-records.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *RFC 7208 behandelt uitsluitend SPF. SMTP TLS Reporting (TLSRPT) en het bijbehorende DNS-record op _smtp._tls worden nergens in de brontekst vermeld.*
+</details>
+
+## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (6)
+
+### `inet-mail-0006` — SKILL.md:56 *(§ 1. SPF (Sender Policy Framework))*
+
+> Internet.nl controleert of SPF maximaal 10 DNS-lookups gebruikt (include, a, mx, redirect).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl SPF-test
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  > SPF implementations MUST limit the total number of those terms to 10 during SPF evaluation, to avoid unreasonable load on the DNS. If this limit is exceeded, the implementation MUST return "permerror". The following terms cause DNS queries: the "include", "a", "mx", "ptr", and "exists" mechanisms, and the "redirect" modifier.
+  - *De bron bevestigt de 10-DNS-lookup-limiet en noemt include, a, mx en redirect als lookup-veroorzakers. De claim over internet.nl die dit controleert valt buiten scope van de bron. De genoemde mechanismen kloppen inhoudelijk, maar de bron noemt ook 'ptr' en 'exists' als lookup-veroorzakers, die de claim weglaat.*
+<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over DNS-lookup limieten in de bron.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 beschrijft DMARC, niet de specifieke SPF-lookup-limietcontrole van internet.nl. De 10-lookup-limiet is onderdeel van de SPF-specificatie (RFC 7208), niet van RFC 7489.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *Gaat over SPF DNS-lookup limiet. Buiten scope van RFC 6376.*
+</details>
+
+### `inet-mail-0010` — SKILL.md:104 *(§ 2. DKIM (DomainKeys Identified Mail))*
+
+> Internet.nl test of de DKIM publieke sleutel beschikbaar is via DNS.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl DKIM-test
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  > The public key for a signature is needed to complete the verification process. The process of retrieving the public key depends on the query type as defined by the "q=" tag in the DKIM-Signature header field.
+  - *RFC 6376 bevestigt dat de publieke sleutel via DNS beschikbaar moet zijn voor verificatie, maar beschrijft niet wat internet.nl specifiek test. Het DNS-opzoekingsaspect wordt volledig ondersteund; het 'internet.nl'-gedeelte is out of scope.*
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over DKIM DNS-beschikbaarheid check in de bron.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 beschrijft DMARC, niet de specifieke internet.nl-controle op beschikbaarheid van DKIM publieke sleutels.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *DKIM en internet.nl vallen buiten scope van RFC 7208.*
+</details>
+
+### `inet-mail-0024` — SKILL.md:222 *(§ 5. DANE (DNS-based Authentication of Named Entities))*
+
+> DANE koppelt TLS-certificaten aan DNS via TLSA-records, beveiligd met DNSSEC.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DANE (DNS-based Authentication of Named Entities)
+
+- **PARTIALLY_SUPPORTED** (low) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  > To reduce the risk of subversion of the DMARC mechanism due to DNS-based exploits, serious consideration should be given to the deployment of DNSSEC in parallel with the deployment of DMARC by both Domain Owners and Mail Receivers.
+  - *RFC 7489 noemt DNSSEC als aanbeveling naast DMARC, maar behandelt DANE of TLSA-records niet expliciet. De claim over DANE koppeling via TLSA-records is niet te verifiëren vanuit deze bron.*
+<details><summary>1x NOT_FOUND + 2x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *De bron noemt DANE maar geeft geen technische beschrijving van TLSA of DNSSEC-koppeling.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De bron is RFC 6376 over DKIM. DANE en TLSA-records worden niet behandeld.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *RFC 7208 gaat over SPF, niet over DANE of TLSA-records.*
+</details>
+
+### `inet-mail-0041` — reference.md:141 *(§ DKIM key rotation)*
+
+> DKIM key rotation wordt aanbevolen elke 6-12 maanden en vereist een nieuwe selector bij elke rotatie.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** DKIM key rotation
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  > Signers are ill-advised to reuse selectors for new keys. A better strategy is to assign new keys to new selectors.
+  - *De bron ondersteunt dat nieuwe sleutels een nieuwe selector vereisen, maar noemt geen aanbevolen rotatie-interval van 6-12 maanden.*
+<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over DKIM key rotation in de bron.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 behandelt geen DKIM key rotation aanbevelingen of intervallen.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *De bron is RFC 7208 (SPF-protocol). DKIM key rotation valt buiten het bereik van deze specificatie.*
+</details>
+
+### `inet-mail-0042` — reference.md:153 *(§ DKIM key rotation)*
+
+> Bij DKIM key rotation moet na het publiceren van het nieuwe DNS-record gewacht worden tot DNS is gepropageerd (controleer TTL) voordat OpenDKIM wordt geconfigureerd.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** DKIM key rotation procedure
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  > if a domain wishes to change from using a public key associated with selector 'january2005' to a public key associated with selector 'february2005', it merely makes sure that both public keys are advertised in the public-key repository concurrently for the transition period during which email may be in transit prior to verification.
+  - *De bron ondersteunt het concept van gelijktijdige publicatie tijdens een transitieperiode, maar noemt niets specifieks over wachten op DNS-propagatie of het controleren van TTL voordat de configuratie wordt gewijzigd.*
+<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over DKIM key rotation procedure in de bron.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 behandelt geen DKIM key rotation procedures of DNS-propagatie stappen.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *De bron is RFC 7208 (SPF-protocol). DKIM key rotation procedure valt buiten het bereik van deze specificatie.*
+</details>
+
+### `inet-mail-0044` — reference.md:170 *(§ DMARC-rapportage analyseren)*
+
+> DMARC-aggregaatrapporten worden dagelijks verstuurd als XML (vaak gzipped) en bevatten statistieken over alle e-mail verstuurd namens het domein.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DMARC-rapportage aggregaat
+
+- **PARTIALLY_SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  > "Visibility comes in the form of daily (or more frequent) Mail Receiver-originated feedback reports that contain aggregate data on message streams relevant to the Domain Owner." en "The aggregate data MUST be an XML file that SHOULD be subjected to GZIP compression."
+  - *De bron bevestigt dagelijkse verzending en XML/gzip-formaat. De claim 'statistieken over alle e-mail verstuurd namens het domein' is deels ondersteund; de RFC zegt dat rapporten data bevatten over berichten die het domein claimen, inclusief geslaagde en mislukte authenticatie, maar spreekt niet expliciet van 'alle e-mail verstuurd namens het domein'.*
+<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over DMARC aggregaatrapporten in de bron.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *DMARC-rapportage (aggregaat of anders) wordt niet behandeld in RFC 6376 over DKIM.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *De bron is RFC 7208 (SPF-protocol). DMARC-rapportage valt buiten het bereik van deze specificatie.*
+</details>
+
+## UNGROUNDED — geen bron ondersteunt de claim (9)
+
+### `inet-mail-0025` — SKILL.md:226 *(§ 5. DANE (DNS-based Authentication of Named Entities))*
+
+> DANE vereist dat DNSSEC actief is op het domein.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** DANE vereisten
+
+<details><summary>2x NOT_FOUND + 2x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over DANE-vereisten in de bron.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 beschrijft DMARC, niet DANE-vereisten. DNSSEC wordt aanbevolen voor DMARC maar DANE-specifieke vereisten worden niet besproken.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De bron is RFC 6376 over DKIM. DANE-vereisten worden niet behandeld.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *RFC 7208 gaat over SPF, niet over DANE/DNSSEC-vereisten.*
+</details>
+
+### `inet-mail-0029` — SKILL.md:242 *(§ 5. DANE (DNS-based Authentication of Named Entities))*
+
+> De aanbevolen TLSA-parameters voor mail zijn: Certificate Usage 3 (DANE-EE), Selector 1 (SubjectPublicKeyInfo), Matching Type 1 (SHA-256).
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** DANE TLSA-parameters voor mail
+
+<details><summary>2x NOT_FOUND + 2x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over aanbevolen TLSA-parameters in de bron.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 beschrijft DMARC, niet DANE TLSA-parameters (Certificate Usage, Selector, Matching Type).*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De bron is RFC 6376 over DKIM. DANE TLSA-parameters voor mail worden niet behandeld.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *RFC 7208 gaat over SPF, niet over aanbevolen TLSA-parameters.*
+</details>
+
+### `inet-mail-0031` — SKILL.md:280 *(§ Veelvoorkomende problemen)*
+
+> DMARC `p=none` is onvoldoende; overheidsorganisaties moeten overschakelen naar `p=quarantine` of `p=reject`.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** DMARC veelvoorkomende problemen
+
+<details><summary>3x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over DMARC p=none voor overheidsorganisaties in de bron.*
+- **NOT_FOUND** (medium) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 beschrijft p=none als een geldig beleid ('The Domain Owner requests no specific action be taken regarding delivery of messages') maar bevat geen normatieve uitspraak dat overheidsorganisaties MOETEN overschakelen naar quarantine of reject. De modality MUST is niet terug te vinden in deze bron.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *Deze bron gaat over DKIM (RFC 6376), niet over DMARC. DMARC-beleid (p=none/quarantine/reject) wordt niet behandeld.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *RFC 7208 gaat over SPF, niet over DMARC-beleid of overheidsverplichtingen.*
+</details>
+
+### `inet-mail-0033` — reference.md:17 *(§ STARTTLS inschakelen)*
+
+> Postfix `smtpd_tls_protocols` moet SSLv2, SSLv3, TLSv1 en TLSv1.1 uitsluiten voor inkomende verbindingen.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Postfix STARTTLS configuratie
+
+<details><summary>3x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over Postfix-configuratie in de bron.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 gaat over DMARC als protocol, niet over Postfix-configuratie of TLS-protocollen.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *Postfix-configuratie en TLS-protocollen vallen buiten de scope van RFC 6376.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *De bron is RFC 7208 (SPF-protocol). Postfix TLS-configuratie valt buiten het bereik van deze specificatie.*
+</details>
+
+### `inet-mail-0035` — reference.md:27 *(§ STARTTLS inschakelen)*
+
+> Postfix `smtp_dns_support_level = dnssec` is vereist voor DANE-ondersteuning bij uitgaande verbindingen.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Postfix DANE configuratie
+
+<details><summary>3x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over Postfix DNSSEC-configuratie in de bron.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 behandelt geen Postfix-configuratie of DNSSEC-instellingen voor DANE.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *Postfix DNSSEC-configuratie valt buiten de scope van RFC 6376.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *De bron is RFC 7208 (SPF-protocol). Postfix DANE-configuratie valt buiten het bereik van deze specificatie.*
+</details>
+
+### `inet-mail-0040` — reference.md:129 *(§ Google Workspace)*
+
+> Google Workspace raadt een DKIM-sleutellengte van 2048-bit aan bij het genereren van een nieuw record.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** Google Workspace DKIM-configuratie
+
+<details><summary>3x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over Google Workspace DKIM-sleutellengte in de bron.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 behandelt geen Google Workspace DKIM-sleutellengte aanbevelingen.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *Google Workspace-specifieke aanbevelingen voor sleutellengte worden niet behandeld. RFC 6376 noemt wel sleutelgroottes maar niet in Google Workspace-context.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *De bron is RFC 7208 (SPF-protocol). Google Workspace DKIM-sleutellengte valt buiten het bereik van deze specificatie.*
+</details>
+
+### `inet-mail-0043` — reference.md:163 *(§ DKIM key rotation)*
+
+> Bij DKIM key rotation moet het oude DNS-record pas na 1-2 weken worden verwijderd.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** DKIM key rotation procedure
+
+<details><summary>3x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over verwijderen van oude DKIM DNS-records in de bron.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 behandelt geen DKIM key rotation procedures of timing voor verwijdering van oude records.*
+- **NOT_FOUND** (medium) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *RFC 6376 beschrijft een transitieperiode waarbij beide sleutels gelijktijdig beschikbaar zijn, maar noemt geen specifieke termijn van 1-2 weken voor het verwijderen van het oude record.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *De bron is RFC 7208 (SPF-protocol). DKIM key rotation timing valt buiten het bereik van deze specificatie.*
+</details>
+
+### `inet-mail-0047` — reference.md:240 *(§ TLSA bijwerken bij certificaatvernieuwing)*
+
+> Bij DANE certificaatvernieuwing moet de pre-publish methode worden gebruikt: publiceer het TLSA-record van het nieuwe certificaat voordat het actief wordt.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** DANE TLSA certificaatvernieuwing
+
+<details><summary>2x NOT_FOUND + 2x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over pre-publish methode voor DANE in de bron.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 behandelt geen DANE certificaatvernieuwing of pre-publish methodes.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *RFC 6376 gaat over DKIM-handtekeningen, niet over DANE of de pre-publish methode voor TLSA-records.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *De bron is RFC 7208 (SPF-protocol). DANE pre-publish methode valt buiten het bereik van deze specificatie.*
+</details>
+
+### `inet-mail-0049` — reference.md:267 *(§ MTA-STS configuratie)*
+
+> MTA-STS vereist een DNS TXT-record op `_mta-sts.example.nl`, een HTTPS-website op `mta-sts.example.nl` met geldig certificaat, en een beleidsbestand op `https://mta-sts.example.nl/.well-known/mta-sts.txt`.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** MTA-STS vereisten
+
+<details><summary>3x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over MTA-STS vereisten in de bron.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 gaat over DMARC, niet over MTA-STS. Geen enkel onderdeel van de MTA-STS vereisten (DNS TXT-record op _mta-sts, HTTPS-website, beleidsbestand) wordt behandeld.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *RFC 6376 gaat over DKIM-handtekeningen, niet over MTA-STS-vereisten zoals DNS TXT-records of beleidsbestanden.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *RFC 7208 behandelt uitsluitend SPF. MTA-STS, DNS TXT-records op _mta-sts, en bijbehorende HTTPS-vereisten komen niet voor in de brontekst.*
+</details>
+
+## GROUNDED — minstens één bron ondersteunt de claim (8)
+
+<details>
+<summary>Klap uit voor alle GROUNDED claims</summary>
+
+### `inet-mail-0001` — SKILL.md:26 *(§ Overzicht)*
+
+> Internet.nl test e-maildomeinen op SPF, DKIM, DMARC, STARTTLS en DANE.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl mailtest
+
+- **SUPPORTED** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  > After you enter a domain name of an email service, we will test if the email service offers support for the modern Internet Standards below. [...] DMARC, DKIM and SPF : authenticity marks against email phishing? STARTTLS and DANE : secure mail server connection?
+- **PARTIALLY_SUPPORTED** (medium) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  > DMARC is a scalable mechanism by which a mail-originating organization can express domain-level policies and preferences for message validation, disposition, and reporting... The following mechanisms for determining Authenticated Identifiers are supported in this version of DMARC: [DKIM]... [SPF]
+  - *RFC 7489 behandelt alleen DMARC (en de relatie met SPF en DKIM). STARTTLS en DANE worden in deze bron niet vermeld. De claim over internet.nl als testplatform wordt ook niet bevestigd.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De bron is RFC 6376 (DKIM specificatie). Internet.nl's testscope (SPF, DKIM, DMARC, STARTTLS, DANE) wordt hier niet behandeld.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *De bron is RFC 7208, de SPF-specificatie. Internet.nl wordt niet genoemd; DKIM, DMARC, STARTTLS en DANE vallen buiten scope van deze bron.*
+
+### `inet-mail-0003` — SKILL.md:50 *(§ 1. SPF (Sender Policy Framework))*
+
+> SPF specificeert welke mailservers e-mail mogen versturen namens een domein via een DNS TXT-record.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** SPF (Sender Policy Framework)
+
+- **SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  > [SPF], which can authenticate both the domain found in an [SMTP] HELO/EHLO command (the HELO identity) and the domain found in an SMTP MAIL command (the MAIL FROM identity)... Domain Owner constructs an SPF policy and publishes it in its DNS database as per [SPF].
+  - *De bron bevestigt dat SPF via DNS gepubliceerd wordt en aangeeft welke mailservers mogen versturen namens een domein. Het DNS TXT-record formaat wordt impliciet bevestigd via de verwijzing naar SPF-publicatie in DNS.*
+- **SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  > SPF-compliant domain publishes valid SPF records as described in Section 3. These records authorize the use of the relevant domain names in the "HELO" and "MAIL FROM" identities by the MTAs specified therein. [...] SPF records MUST be published as a DNS TXT (type 16) Resource Record (RR)
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *De bron noemt SPF enkel als categorie, maar geeft geen technische beschrijving van hoe SPF werkt.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De bron gaat over DKIM, niet over SPF (Sender Policy Framework). SPF wordt in RFC 6376 niet gedefinieerd of beschreven.*
+
+### `inet-mail-0008` — SKILL.md:99 *(§ 2. DKIM (DomainKeys Identified Mail))*
+
+> DKIM voorziet e-mail van een cryptografische handtekening via een DNS-publicsleutel die de ontvangende mailserver verifieert.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DKIM (DomainKeys Identified Mail)
+
+- **SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  > [DKIM], which provides a domain-level identifier in the content of the 'd=' tag of a validated DKIM-Signature header field... Submission service passes relevant details to the DKIM signing module in order to generate a DKIM signature to be applied to the message.
+  - *De bron bevestigt dat DKIM een cryptografische handtekening toevoegt via een DNS-gepubliceerde sleutel die de ontvangende mailserver verifieert.*
+- **SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  > DKIM permits a person, role, or organization that owns the signing domain to claim some responsibility for a message by associating the domain with the message. Assertion of responsibility is validated through a cryptographic signature and by querying the Signer's domain directly to retrieve the appropriate public key.
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *De bron noemt DKIM enkel als categorie zonder technische beschrijving.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *DKIM wordt niet behandeld in RFC 7208; dit is een SPF-specificatie.*
+
+### `inet-mail-0012` — SKILL.md:107 *(§ 2. DKIM (DomainKeys Identified Mail))*
+
+> RFC 6376 vereist minimaal 1024-bit RSA voor langlevende DKIM-sleutels.
+
+**Type:** reference_claim  ·  **Modaliteit:** MUST  ·  **Scope:** DKIM RFC 6376
+
+- **SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  > Signers MUST use RSA keys of at least 1024 bits for long-lived keys. Verifiers MUST be able to validate signatures with keys ranging from 512 bits to 2048 bits, and they MAY be able to validate signatures with larger keys.
+
+### `inet-mail-0013` — SKILL.md:108 *(§ 2. DKIM (DomainKeys Identified Mail))*
+
+> 2048-bit RSA is de huidige operationele aanbeveling voor DKIM-sleutels (o.a. NIST, M3AAWG), niet een eis uit RFC 6376.
+
+**Type:** factual_assertion  ·  **Modaliteit:** SHOULD  ·  **Scope:** DKIM sleutellengte aanbeveling
+
+- **SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  > Signers MUST use RSA keys of at least 1024 bits for long-lived keys.
+  - *RFC 6376 schrijft alleen 1024-bit als minimum voor. De claim dat 2048-bit een aanbeveling is van NIST/M3AAWG en níet een eis uit RFC 6376 is correct: de bron noemt geen 2048-bit eis of aanbeveling, alleen een minimum van 1024-bit.*
+
+### `inet-mail-0014` — SKILL.md:150 *(§ 3. DMARC (Domain-based Message Authentication, Reporting and Conformance))*
+
+> Het DMARC-record staat op `_dmarc.example.nl` als DNS TXT-record.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DMARC DNS-record
+
+- **SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  > Domain Owner DMARC preferences are stored as DNS TXT records in subdomains named '_dmarc'. For example, the Domain Owner of 'example.com' would post DMARC preferences in a TXT record at '_dmarc.example.com'.
+  - *De bron bevestigt exact dit patroon, met 'example.com' als voorbeeld. De claim gebruikt 'example.nl' maar het principe is identiek.*
+<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *De bron geeft geen technische details over DMARC DNS-records.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De claim gaat over DMARC DNS-records (_dmarc.example.nl). RFC 6376 gaat over DKIM; DMARC wordt niet behandeld.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *DMARC wordt niet behandeld in RFC 7208.*
+</details>
+
+### `inet-mail-0017` — SKILL.md:154 *(§ 3. DMARC (Domain-based Message Authentication, Reporting and Conformance))*
+
+> DMARC implementatiepad: start met `p=none` om rapportages te verzamelen, schakel daarna over naar `quarantine` en uiteindelijk `reject`.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** DMARC gefaseerde uitrol
+
+- **SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  > The owner of the domain 'example.com' has deployed SPF and DKIM on its messaging infrastructure. The owner wishes to begin using DMARC with a policy that will solicit aggregate feedback from receivers without affecting how the messages are processed... ('p=none')... The Domain Owner accomplishes this by constructing a policy record... Receivers should quarantine messages from this Organizationa...
+  - *De bron illustreert expliciet het gefaseerde implementatiepad: beginnen met p=none voor rapportages, dan quarantine, en de reject-optie wordt ook beschreven als eindstadium.*
+<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen implementatieadvies of fasering voor DMARC in de bron.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De bron is RFC 6376 over DKIM. DMARC-implementatiepad wordt niet behandeld.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  - *DMARC-implementatieadvies valt buiten scope van RFC 7208.*
+</details>
+
+### `inet-mail-0030` — SKILL.md:278 *(§ Veelvoorkomende problemen)*
+
+> Een SPF `permerror` wordt veroorzaakt door meer dan 10 DNS-lookups; oplossing is minder `include`-verwijzingen en direct gebruik van `ip4`/`ip6`.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** SPF veelvoorkomende problemen
+
+- **SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc7208.txt](https://www.rfc-editor.org/rfc/rfc7208.txt)
+  > SPF implementations MUST limit the total number of those terms to 10 during SPF evaluation, to avoid unreasonable load on the DNS. If this limit is exceeded, the implementation MUST return "permerror".
+  - *De bron bevestigt dat overschrijding van 10 DNS-lookups een permerror oplevert. De oplossingsrichting (minder includes, direct ip4/ip6) wordt impliciet ondersteund door Section 10.1.1 die ip4/ip6 als 'Best record' aanbeveelt.*
+<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-mail/](https://internet.nl/test-mail/)
+  - *Geen informatie over SPF permerror of DNS-lookup problemen in de bron.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7489.txt](https://www.rfc-editor.org/rfc/rfc7489.txt)
+  - *RFC 7489 beschrijft DMARC. SPF permerror door meer dan 10 DNS-lookups wordt niet behandeld in deze bron.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6376.txt](https://www.rfc-editor.org/rfc/rfc6376.txt)
+  - *De bron is RFC 6376 over DKIM. SPF en DNS-lookup limieten worden niet behandeld.*
+</details>
+
+</details>

--- a/skills/inet-toolbox/audit.md
+++ b/skills/inet-toolbox/audit.md
@@ -1,0 +1,463 @@
+<!-- markdownlint-disable MD052 MD034 MD013 -->
+# Audit inet-toolbox — 2026-05-17
+
+> Automatisch gegenereerd door audit-tooling. Niet handmatig bewerken; wijzig SKILL.md / reference.md en regenereer.
+
+## Samenvatting
+
+| Status | Aantal | % |
+|--------|--------|---|
+| UNSUPPORTED_ASSERTION | 12 | 31% |
+| CONTRADICTED | 0 | 0% |
+| PARTIALLY_GROUNDED | 1 | 3% |
+| UNGROUNDED | 25 | 64% |
+| NO_SOURCE | 0 | 0% |
+| UNVERIFIABLE | 0 | 0% |
+| KNOWN_DISCREPANCY | 0 | 0% |
+| GROUNDED | 1 | 3% |
+
+*Geverifieerd met sonnet, 2 calls, $0.2221.*
+
+## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (12)
+
+### `inet-toolbox-0002` — SKILL.md:46 *(§ 1. DNSSEC instellen)*
+
+> DNSSEC beveiligt DNS-antwoorden met cryptografische handtekeningen.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DNSSEC
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *De bron bevat geen technische uitleg over DNSSEC of cryptografische handtekeningen.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *De brontekst (alleen de README/landingspagina van de repo) bevat geen inhoudelijke uitleg over DNSSEC of cryptografische handtekeningen.*
+
+### `inet-toolbox-0003` — SKILL.md:64 *(§ 1. DNSSEC instellen)*
+
+> Voor BIND 9 DNSSEC worden twee sleutels gegenereerd: een KSK (Key Signing Key) en een ZSK (Zone Signing Key) met algoritme ECDSAP256SHA256.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DNSSEC / BIND 9
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Geen informatie over BIND 9, KSK, ZSK of ECDSAP256SHA256 in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen inhoud over BIND 9, KSK, ZSK of ECDSAP256SHA256 in de aangeleverde brontekst.*
+
+### `inet-toolbox-0005` — SKILL.md:82 *(§ 1. DNSSEC instellen)*
+
+> NSD gebruikt externe tools voor DNSSEC, zoals ldns of OpenDNSSEC.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DNSSEC / NSD
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Geen informatie over NSD, ldns of OpenDNSSEC in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen inhoud over NSD, ldns of OpenDNSSEC in de aangeleverde brontekst.*
+
+### `inet-toolbox-0007` — SKILL.md:158 *(§ 2. HTTPS/TLS configureren)*
+
+> De Nginx TLS-configuratie bevat `ssl_prefer_server_ciphers off`.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** HTTPS/TLS / Nginx
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Geen informatie over ssl_prefer_server_ciphers in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen inhoud over ssl_prefer_server_ciphers in de aangeleverde brontekst.*
+
+### `inet-toolbox-0014` — SKILL.md:265 *(§ 4. DKIM instellen)*
+
+> Postfix wordt aan OpenDKIM gekoppeld via een milter op `inet:localhost:8891`.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DKIM / Postfix / OpenDKIM
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Geen informatie over Postfix, OpenDKIM of milter-configuratie in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen inhoud over Postfix/OpenDKIM milter-configuratie in de aangeleverde brontekst.*
+
+### `inet-toolbox-0019` — SKILL.md:328 *(§ 6. DANE instellen)*
+
+> DANE TLSA-record voor SMTP heeft het formaat `_25._tcp.mx.example.nl. IN TLSA 3 1 1 <hash>`.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DANE
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Geen informatie over DANE TLSA-records of SMTP-formaten in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen inhoud over TLSA-recordformaat in de aangeleverde brontekst.*
+
+### `inet-toolbox-0022` — SKILL.md:395 *(§ Veelvoorkomende problemen)*
+
+> SPF permerror wordt veroorzaakt door meer dan 10 DNS-lookups in het SPF-record.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** SPF
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Geen informatie over SPF permerror of DNS-lookup limieten in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen inhoud over SPF permerror in de aangeleverde brontekst.*
+
+### `inet-toolbox-0023` — SKILL.md:396 *(§ Veelvoorkomende problemen)*
+
+> DANE TLSA mismatch na certificaatvernieuwing wordt veroorzaakt door een niet-bijgewerkt TLSA-record; oplossing is SPKI (selector=1) met hergebruik privésleutel of vooraf TLSA updaten.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DANE
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Geen informatie over DANE TLSA mismatch of SPKI in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen inhoud over DANE TLSA mismatch of SPKI in de aangeleverde brontekst.*
+
+### `inet-toolbox-0028` — reference.md:54 *(§ DNSSEC - geavanceerde configuratie)*
+
+> ECDSAP256SHA256 heeft algoritme-code 13 in DNSSEC.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DNSSEC / algoritme-keuze
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Geen informatie over DNSSEC algoritme-codes in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen inhoud over DNSSEC algoritme-codes in de aangeleverde brontekst.*
+
+### `inet-toolbox-0029` — reference.md:56 *(§ DNSSEC - geavanceerde configuratie)*
+
+> ED25519 heeft algoritme-code 15 in DNSSEC.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DNSSEC / algoritme-keuze
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Geen informatie over ED25519 of algoritme-code 15 in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen inhoud over ED25519 algoritme-code in de aangeleverde brontekst.*
+
+### `inet-toolbox-0030` — reference.md:153 *(§ E-mailbeveiliging - geavanceerde configuratie)*
+
+> Postfix `smtp_tls_security_level = dane` configureert uitgaand SMTP voor DANE-verificatie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DANE / Postfix TLS
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Geen informatie over Postfix smtp_tls_security_level in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen inhoud over Postfix smtp_tls_security_level in de aangeleverde brontekst.*
+
+### `inet-toolbox-0039` — SKILL.md:386 *(§ Repositories)*
+
+> Internet.nl testsuite is gepubliceerd onder Apache-2.0 (code) en CC-BY-4.0 (vertalingen).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl / licentie
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *De bron vermeldt alleen versienummer v1.11.0 van internet.nl, maar geen licentie-informatie. De Hall of Fame pagina bevat geen verwijzing naar Apache-2.0 of CC-BY-4.0.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *De brontekst gaat over de toolbox-wiki repository, niet over de Internet.nl testsuite zelf. Geen informatie over Apache-2.0 of licenties van Internet.nl code/vertalingen.*
+
+## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (1)
+
+### `inet-toolbox-0001` — SKILL.md:26 *(§ Overzicht)*
+
+> De toolbox-wiki bevat implementatiegidsen voor alle standaarden die internet.nl test.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** inet-toolbox skill / toolbox-wiki
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  > Quick access: DANE how-to, DKIM how-to, SPF how-to, DMARC how-to, Parked domain how-to
+  - *De bron toont how-to's voor DANE, DKIM, SPF, DMARC en parked domains. Internet.nl test ook DNSSEC, IPv6, HTTPS/TLS en andere standaarden waarvoor geen how-to's zichtbaar zijn in deze README. De claim 'alle standaarden' is dus te sterk.*
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *De brontekst is de Hall of Fame pagina van internet.nl met een lijst van domeinen die 100% scoren. Er is geen informatie over een toolbox-wiki of implementatiegidsen.*
+
+## UNGROUNDED — geen bron ondersteunt de claim (25)
+
+### `inet-toolbox-0004` — SKILL.md:73 *(§ 1. DNSSEC instellen)*
+
+> Na het genereren van DNSSEC-sleutels in BIND 9 moet het DS-record gepubliceerd worden bij de domeinregistrar.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** DNSSEC / BIND 9
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Geen informatie over DS-records of domeinregistrars in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen inhoud over DS-records of domeinregistrars in de aangeleverde brontekst.*
+
+### `inet-toolbox-0006` — SKILL.md:155 *(§ 2. HTTPS/TLS configureren)*
+
+> De Nginx TLS-configuratie dient `ssl_protocols TLSv1.2 TLSv1.3` te gebruiken (NCSC-conform).
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** HTTPS/TLS / Nginx
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Geen Nginx TLS-configuratie informatie in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen inhoud over Nginx TLS-configuratie in de aangeleverde brontekst.*
+
+### `inet-toolbox-0008` — SKILL.md:166 *(§ 2. HTTPS/TLS configureren)*
+
+> Nginx HSTS-header moet `max-age=31536000; includeSubDomains` bevatten.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** HTTPS/TLS / Nginx / HSTS
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Geen informatie over HSTS-headers of max-age in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen inhoud over Nginx HSTS-configuratie in de aangeleverde brontekst.*
+
+### `inet-toolbox-0009` — SKILL.md:197 *(§ 2. HTTPS/TLS configureren)*
+
+> Apache TLS-configuratie sluit SSLv3, TLSv1 en TLSv1.1 uit via `SSLProtocol all -SSLv3 -TLSv1 -TLSv1.1`.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** HTTPS/TLS / Apache
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Geen informatie over Apache TLS-configuratie in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen inhoud over Apache TLS-configuratie in de aangeleverde brontekst.*
+
+### `inet-toolbox-0010` — SKILL.md:203 *(§ 2. HTTPS/TLS configureren)*
+
+> Apache HSTS-header moet `max-age=31536000; includeSubDomains` bevatten.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** HTTPS/TLS / Apache / HSTS
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Geen informatie over Apache HSTS-headers in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen inhoud over Apache HSTS-configuratie in de aangeleverde brontekst.*
+
+### `inet-toolbox-0011` — SKILL.md:218 *(§ 3. DMARC gefaseerd uitrollen)*
+
+> DMARC wordt gefaseerd uitgerold: eerst p=none (monitor), dan p=quarantine met oplopende pct, dan p=reject.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** DMARC
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Geen informatie over DMARC-uitrol of policies in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen inhoud over DMARC-uitrolstrategie in de aangeleverde brontekst. Er is alleen een verwijzing naar DMARC-how-to.md, maar de inhoud daarvan is niet aangeleverd.*
+
+### `inet-toolbox-0012` — SKILL.md:222 *(§ 3. DMARC gefaseerd uitrollen)*
+
+> In de monitor-fase van DMARC-uitrol wordt 2 tot 4 weken gewacht om rapporten te analyseren voordat de policy wordt aangescherpt.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** DMARC
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Geen informatie over DMARC monitor-fase of wachttijden in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen inhoud over DMARC monitor-fase of wachttijden in de aangeleverde brontekst.*
+
+### `inet-toolbox-0013` — SKILL.md:245 *(§ 4. DKIM instellen)*
+
+> Een DKIM RSA-sleutelpaar heeft minimaal 2048 bits.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** DKIM
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Geen informatie over DKIM RSA-sleutellengte in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen inhoud over DKIM sleutellengte in de aangeleverde brontekst.*
+
+### `inet-toolbox-0015` — SKILL.md:298 *(§ 5. SPF-record samenstellen)*
+
+> SPF mag maximaal 10 DNS-lookups bevatten; elke `include`, `a`, `mx` en `redirect` telt als 1 lookup.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** SPF
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Geen informatie over SPF DNS-lookup limieten in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen inhoud over SPF DNS-lookup limiet in de aangeleverde brontekst.*
+
+### `inet-toolbox-0016` — SKILL.md:300 *(§ 5. SPF-record samenstellen)*
+
+> SPF-records moeten eindigen met `-all` (fail) of `~all` (softfail).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** SPF
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Geen informatie over SPF -all of ~all in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen inhoud over SPF -all of ~all in de aangeleverde brontekst.*
+
+### `inet-toolbox-0017` — SKILL.md:299 *(§ 5. SPF-record samenstellen)*
+
+> Gebruik `ip4`/`ip6` in SPF om DNS-lookups te besparen.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** SPF
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Geen informatie over SPF ip4/ip6 mechanismen in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen inhoud over ip4/ip6 mechanismen in SPF in de aangeleverde brontekst.*
+
+### `inet-toolbox-0018` — SKILL.md:315 *(§ 6. DANE instellen)*
+
+> DANE vereist dat DNSSEC actief is op het MX-domein.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** DANE
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Geen informatie over DANE of DNSSEC-vereisten in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen inhoud over DANE-vereisten of DNSSEC-afhankelijkheid in de aangeleverde brontekst.*
+
+### `inet-toolbox-0020` — SKILL.md:335 *(§ 6. DANE instellen)*
+
+> Bij DANE met hergebruik van dezelfde privésleutel hoeft het TLSA-record niet te veranderen bij certificaatvernieuwing.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MAY  ·  **Scope:** DANE
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Geen informatie over DANE certificaatvernieuwing of privésleutelhergebruik in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen inhoud over DANE privésleutel hergebruik in de aangeleverde brontekst.*
+
+### `inet-toolbox-0021` — SKILL.md:336 *(§ 6. DANE instellen)*
+
+> Bij DANE met een nieuwe sleutel moet het TLSA-record worden bijgewerkt VOOR de certificaatvernieuwing.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** DANE
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Geen informatie over DANE TLSA-record updates bij sleutelwisseling in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen inhoud over TLSA-update timing bij certificaatvernieuwing in de aangeleverde brontekst.*
+
+### `inet-toolbox-0024` — reference.md:30 *(§ DNSSEC - geavanceerde configuratie)*
+
+> ZSK rollover wordt aanbevolen elke 3 maanden.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** DNSSEC / key rollover
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Geen informatie over ZSK rollover-intervallen in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen inhoud over ZSK rollover-interval in de aangeleverde brontekst.*
+
+### `inet-toolbox-0025` — reference.md:39 *(§ DNSSEC - geavanceerde configuratie)*
+
+> KSK rollover wordt aanbevolen jaarlijks.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** DNSSEC / key rollover
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Geen informatie over KSK rollover-intervallen in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen inhoud over KSK rollover-interval in de aangeleverde brontekst.*
+
+### `inet-toolbox-0026` — reference.md:44 *(§ DNSSEC - geavanceerde configuratie)*
+
+> Bij KSK rollover moet het nieuwe DS-record bij de registrar gepubliceerd worden (naast het oude) voordat de DNSKEY RRset met de nieuwe KSK wordt ondertekend.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** DNSSEC / KSK rollover
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Geen informatie over KSK rollover-procedure of DS-records in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen inhoud over KSK rollover-procedure in de aangeleverde brontekst.*
+
+### `inet-toolbox-0027` — reference.md:59 *(§ DNSSEC - geavanceerde configuratie)*
+
+> ECDSAP256SHA256 (algoritme 13) is het aanbevolen algoritme voor nieuwe DNSSEC-zones vanwege compacte handtekeningen, brede ondersteuning en goede prestaties.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** DNSSEC / algoritme-keuze
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Geen informatie over ECDSAP256SHA256 of aanbevolen DNSSEC-algoritmen in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen inhoud over ECDSAP256SHA256 als aanbevolen algoritme in de aangeleverde brontekst.*
+
+### `inet-toolbox-0031` — reference.md:160 *(§ E-mailbeveiliging - geavanceerde configuratie)*
+
+> Postfix `smtp_dns_support_level = dnssec` is vereist voor DANE-ondersteuning bij uitgaand SMTP.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** DANE / Postfix TLS
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Geen informatie over Postfix smtp_dns_support_level in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen inhoud over Postfix smtp_dns_support_level in de aangeleverde brontekst.*
+
+### `inet-toolbox-0032` — reference.md:142 *(§ E-mailbeveiliging - geavanceerde configuratie)*
+
+> Postfix TLS sluit SSLv2, SSLv3, TLSv1 en TLSv1.1 uit via `smtpd_tls_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1`.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** HTTPS/TLS / Postfix
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Geen informatie over Postfix TLS-protocollen of smtpd_tls_protocols in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen inhoud over Postfix smtpd_tls_protocols in de aangeleverde brontekst.*
+
+### `inet-toolbox-0033` — reference.md:191 *(§ E-mailbeveiliging - geavanceerde configuratie)*
+
+> SPF-flattening is een oplossing wanneer je tegen de 10 DNS-lookup limiet aanloopt: vervang `include` door directe ip4:/ip6: regels.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** SPF
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Geen informatie over SPF-flattening in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen inhoud over SPF-flattening in de aangeleverde brontekst.*
+
+### `inet-toolbox-0034` — reference.md:239 *(§ DANE - geavanceerde configuratie)*
+
+> Bij DANE voor meerdere MX-servers moet elke MX een eigen TLSA-record hebben onder `_25._tcp.<mx-hostname>`.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** DANE / meerdere MX-servers
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Geen informatie over DANE met meerdere MX-servers in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen inhoud over DANE voor meerdere MX-servers in de aangeleverde brontekst.*
+
+### `inet-toolbox-0035` — reference.md:230 *(§ DANE - geavanceerde configuratie)*
+
+> Voor DANE-rollover kunnen meerdere TLSA-records tegelijk gepubliceerd worden: het huidige en het toekomstige certificaat naast elkaar.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MAY  ·  **Scope:** DANE / certificaatrollover
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Geen informatie over DANE-rollover of meerdere TLSA-records in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen inhoud over DANE-rollover met meerdere TLSA-records in de aangeleverde brontekst.*
+
+### `inet-toolbox-0036` — reference.md:281 *(§ IPv6 - geavanceerde configuratie)*
+
+> ICMPv6 moet geaccepteerd worden in de firewall (nftables) omdat het nodig is voor IPv6-werking.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** IPv6 / firewall
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Geen informatie over IPv6, ICMPv6 of nftables in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen inhoud over ICMPv6 of nftables in de aangeleverde brontekst.*
+
+### `inet-toolbox-0037` — reference.md:122 *(§ HTTPS/TLS - geavanceerde configuratie)*
+
+> Let's Encrypt wildcard-certificaten vereisen een DNS-challenge (`--preferred-challenges dns`).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** HTTPS/TLS / Let's Encrypt
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Geen informatie over Let's Encrypt wildcard-certificaten of DNS-challenges in de brontekst.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen inhoud over Let's Encrypt wildcard-certificaten of DNS-challenge in de aangeleverde brontekst.*
+
+## GROUNDED — minstens één bron ondersteunt de claim (1)
+
+<details>
+<summary>Klap uit voor alle GROUNDED claims</summary>
+
+### `inet-toolbox-0038` — SKILL.md:385 *(§ Repositories)*
+
+> De toolbox-wiki is gepubliceerd onder de CC-BY-4.0 licentie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** toolbox-wiki / licentie
+
+- **SUPPORTED** (medium) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  > LICENSE-CC-BY-4.0.txt
+  - *De repository bevat een bestand genaamd LICENSE-CC-BY-4.0.txt, wat sterk impliceert dat de CC-BY-4.0 licentie van toepassing is. De bestandsnaam is geen expliciete verklaring, maar is voldoende directe aanwijzing. Confidence medium omdat de volledige licentietekst niet is weergegeven.*
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Geen informatie over licenties van de toolbox-wiki in de brontekst.*
+
+</details>

--- a/skills/inet-toolbox/audit.md
+++ b/skills/inet-toolbox/audit.md
@@ -7,457 +7,451 @@
 
 | Status | Aantal | % |
 |--------|--------|---|
-| UNSUPPORTED_ASSERTION | 12 | 31% |
+| UNSUPPORTED_ASSERTION | 11 | 29% |
 | CONTRADICTED | 0 | 0% |
-| PARTIALLY_GROUNDED | 1 | 3% |
-| UNGROUNDED | 25 | 64% |
+| PARTIALLY_GROUNDED | 0 | 0% |
+| UNGROUNDED | 26 | 68% |
 | NO_SOURCE | 0 | 0% |
 | UNVERIFIABLE | 0 | 0% |
 | KNOWN_DISCREPANCY | 0 | 0% |
 | GROUNDED | 1 | 3% |
 
-*Geverifieerd met sonnet, 2 calls, $0.2221.*
+*Geverifieerd met sonnet, 2 calls, $0.2159.*
 
-## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (12)
+## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (11)
 
-### `inet-toolbox-0002` — SKILL.md:46 *(§ 1. DNSSEC instellen)*
+### `inet-toolbox-0001` — SKILL.md:46 *(§ 1. DNSSEC instellen)*
 
 > DNSSEC beveiligt DNS-antwoorden met cryptografische handtekeningen.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DNSSEC
 
 - **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *De bron bevat geen technische uitleg over DNSSEC of cryptografische handtekeningen.*
+  - *De brontekst is uitsluitend een lijst van 3133 domeinen die 100% scoren op de Hall of Fame van internet.nl. Er staat geen technische uitleg over DNSSEC, DANE, SPF, DMARC of andere protocollen.*
 - **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *De brontekst (alleen de README/landingspagina van de repo) bevat geen inhoudelijke uitleg over DNSSEC of cryptografische handtekeningen.*
+  - *De brontekst is de README/landingspagina van de toolbox-wiki GitHub repository. Deze bevat geen technische uitleg over DNSSEC of cryptografische handtekeningen.*
 
-### `inet-toolbox-0003` — SKILL.md:64 *(§ 1. DNSSEC instellen)*
+### `inet-toolbox-0008` — SKILL.md:218 *(§ 3. DMARC gefaseerd uitrollen)*
 
-> Voor BIND 9 DNSSEC worden twee sleutels gegenereerd: een KSK (Key Signing Key) en een ZSK (Zone Signing Key) met algoritme ECDSAP256SHA256.
+> DMARC fase 1 (monitor) gebruikt `p=none` met een `rua`-adres voor rapportages zonder impact op mailbezorging.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DNSSEC / BIND 9
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DMARC
 
 - **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *Geen informatie over BIND 9, KSK, ZSK of ECDSAP256SHA256 in de brontekst.*
+  - *Bron bevat geen technische informatie over DMARC.*
 - **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *Geen inhoud over BIND 9, KSK, ZSK of ECDSAP256SHA256 in de aangeleverde brontekst.*
+  - *Geen technische DMARC-inhoud over fasen of p=none in de aangeleverde brontekst.*
 
-### `inet-toolbox-0005` — SKILL.md:82 *(§ 1. DNSSEC instellen)*
+### `inet-toolbox-0009` — SKILL.md:224 *(§ 3. DMARC gefaseerd uitrollen)*
 
-> NSD gebruikt externe tools voor DNSSEC, zoals ldns of OpenDNSSEC.
+> DMARC fase 2 gebruikt `p=quarantine` met een `pct`-waarde die geleidelijk verhoogd wordt (10, 25, 50, 100).
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DNSSEC / NSD
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DMARC
 
 - **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *Geen informatie over NSD, ldns of OpenDNSSEC in de brontekst.*
+  - *Bron bevat geen technische informatie over DMARC.*
 - **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *Geen inhoud over NSD, ldns of OpenDNSSEC in de aangeleverde brontekst.*
+  - *Geen technische DMARC-inhoud over p=quarantine of pct-waarden in de aangeleverde brontekst.*
 
-### `inet-toolbox-0007` — SKILL.md:158 *(§ 2. HTTPS/TLS configureren)*
+### `inet-toolbox-0010` — SKILL.md:229 *(§ 3. DMARC gefaseerd uitrollen)*
 
-> De Nginx TLS-configuratie bevat `ssl_prefer_server_ciphers off`.
+> DMARC fase 3 (streng) gebruikt `p=reject` met `adkim=s` en `aspf=s`.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** HTTPS/TLS / Nginx
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DMARC
 
 - **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *Geen informatie over ssl_prefer_server_ciphers in de brontekst.*
+  - *Bron bevat geen technische informatie over DMARC.*
 - **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *Geen inhoud over ssl_prefer_server_ciphers in de aangeleverde brontekst.*
+  - *Geen technische DMARC-inhoud over p=reject, adkim=s of aspf=s in de aangeleverde brontekst.*
 
-### `inet-toolbox-0014` — SKILL.md:265 *(§ 4. DKIM instellen)*
+### `inet-toolbox-0011` — SKILL.md:395 *(§ Veelvoorkomende problemen)*
 
-> Postfix wordt aan OpenDKIM gekoppeld via een milter op `inet:localhost:8891`.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DKIM / Postfix / OpenDKIM
-
-- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *Geen informatie over Postfix, OpenDKIM of milter-configuratie in de brontekst.*
-- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *Geen inhoud over Postfix/OpenDKIM milter-configuratie in de aangeleverde brontekst.*
-
-### `inet-toolbox-0019` — SKILL.md:328 *(§ 6. DANE instellen)*
-
-> DANE TLSA-record voor SMTP heeft het formaat `_25._tcp.mx.example.nl. IN TLSA 3 1 1 <hash>`.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DANE
-
-- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *Geen informatie over DANE TLSA-records of SMTP-formaten in de brontekst.*
-- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *Geen inhoud over TLSA-recordformaat in de aangeleverde brontekst.*
-
-### `inet-toolbox-0022` — SKILL.md:395 *(§ Veelvoorkomende problemen)*
-
-> SPF permerror wordt veroorzaakt door meer dan 10 DNS-lookups in het SPF-record.
+> SPF permerror treedt op wanneer er meer dan 10 DNS-lookups zijn; oplossing is `include` vervangen door `ip4`/`ip6` waar mogelijk.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** SPF
 
 - **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *Geen informatie over SPF permerror of DNS-lookup limieten in de brontekst.*
+  - *Bron bevat geen technische informatie over SPF.*
 - **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *Geen inhoud over SPF permerror in de aangeleverde brontekst.*
+  - *Geen technische SPF-inhoud over permerror of oplossingen daarvoor in de aangeleverde brontekst.*
 
-### `inet-toolbox-0023` — SKILL.md:396 *(§ Veelvoorkomende problemen)*
+### `inet-toolbox-0013` — SKILL.md:361 *(§ 7. IPv6 inschakelen)*
 
-> DANE TLSA mismatch na certificaatvernieuwing wordt veroorzaakt door een niet-bijgewerkt TLSA-record; oplossing is SPKI (selector=1) met hergebruik privésleutel of vooraf TLSA updaten.
+> Nginx luistert op IPv4 én IPv6 wanneer `listen [::]:80` en `listen [::]:443 ssl` worden toegevoegd naast de IPv4 listen-directives.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DANE
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IPv6 / Nginx
 
 - **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *Geen informatie over DANE TLSA mismatch of SPKI in de brontekst.*
+  - *Bron bevat geen Nginx-configuratie-informatie.*
 - **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *Geen inhoud over DANE TLSA mismatch of SPKI in de aangeleverde brontekst.*
+  - *Geen technische Nginx/IPv6-inhoud in de aangeleverde brontekst.*
 
-### `inet-toolbox-0028` — reference.md:54 *(§ DNSSEC - geavanceerde configuratie)*
+### `inet-toolbox-0021` — SKILL.md:386 *(§ Repositories)*
 
-> ECDSAP256SHA256 heeft algoritme-code 13 in DNSSEC.
+> Internet.nl code is gepubliceerd onder Apache-2.0; vertalingen onder CC-BY-4.0.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl
+
+- **SOURCE_UNAVAILABLE** (high) — [https://raw.githubusercontent.com/internetstandards/Internet.nl/main/LICENSE](https://raw.githubusercontent.com/internetstandards/Internet.nl/main/LICENSE)
+  - *Bron status: unreachable*
+- **SOURCE_UNAVAILABLE** (high) — [https://raw.githubusercontent.com/internetstandards/Internet.nl/master/LICENSE](https://raw.githubusercontent.com/internetstandards/Internet.nl/master/LICENSE)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Bron bevat geen licentie-informatie over internet.nl code of vertalingen.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *De brontekst gaat over de toolbox-wiki repository, niet over de Internet.nl codebase zelf. Er is geen vermelding van Apache-2.0 licentie voor Internet.nl code.*
+
+### `inet-toolbox-0027` — reference.md:55 *(§ DNSSEC - geavanceerde configuratie)*
+
+> ECDSAP384SHA384 (algoritme 14) is een goed DNSSEC-algoritme: sterker maar met grotere handtekeningen.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DNSSEC / algoritme-keuze
 
 - **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *Geen informatie over DNSSEC algoritme-codes in de brontekst.*
+  - *Bron bevat geen informatie over DNSSEC algoritme-keuze.*
 - **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *Geen inhoud over DNSSEC algoritme-codes in de aangeleverde brontekst.*
+  - *Geen technische DNSSEC-inhoud over ECDSAP384SHA384 in de aangeleverde brontekst.*
 
-### `inet-toolbox-0029` — reference.md:56 *(§ DNSSEC - geavanceerde configuratie)*
+### `inet-toolbox-0028` — reference.md:56 *(§ DNSSEC - geavanceerde configuratie)*
 
-> ED25519 heeft algoritme-code 15 in DNSSEC.
+> ED25519 (algoritme 15) is een goed DNSSEC-algoritme: nieuwste en compact.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DNSSEC / algoritme-keuze
 
 - **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *Geen informatie over ED25519 of algoritme-code 15 in de brontekst.*
+  - *Bron bevat geen informatie over DNSSEC algoritme-keuze.*
 - **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *Geen inhoud over ED25519 algoritme-code in de aangeleverde brontekst.*
+  - *Geen technische DNSSEC-inhoud over ED25519 in de aangeleverde brontekst.*
 
-### `inet-toolbox-0030` — reference.md:153 *(§ E-mailbeveiliging - geavanceerde configuratie)*
+### `inet-toolbox-0029` — reference.md:57 *(§ DNSSEC - geavanceerde configuratie)*
 
-> Postfix `smtp_tls_security_level = dane` configureert uitgaand SMTP voor DANE-verificatie.
+> RSASHA256 (algoritme 8) is voldoende als DNSSEC-algoritme en breed ondersteund.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DANE / Postfix TLS
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DNSSEC / algoritme-keuze
 
 - **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *Geen informatie over Postfix smtp_tls_security_level in de brontekst.*
+  - *Bron bevat geen informatie over DNSSEC algoritme-keuze.*
 - **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *Geen inhoud over Postfix smtp_tls_security_level in de aangeleverde brontekst.*
+  - *Geen technische DNSSEC-inhoud over RSASHA256 in de aangeleverde brontekst.*
 
-### `inet-toolbox-0039` — SKILL.md:386 *(§ Repositories)*
+### `inet-toolbox-0036` — reference.md:229 *(§ DANE - geavanceerde configuratie)*
 
-> Internet.nl testsuite is gepubliceerd onder Apache-2.0 (code) en CC-BY-4.0 (vertalingen).
+> Bij DANE rollover kunnen twee TLSA-records tegelijk gepubliceerd worden: één voor het huidige en één voor het toekomstige certificaat (pre-publish methode).
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl / licentie
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DANE / TLSA rollover
 
 - **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *De bron vermeldt alleen versienummer v1.11.0 van internet.nl, maar geen licentie-informatie. De Hall of Fame pagina bevat geen verwijzing naar Apache-2.0 of CC-BY-4.0.*
+  - *Bron bevat geen informatie over DANE/TLSA rollover methodes.*
 - **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *De brontekst gaat over de toolbox-wiki repository, niet over de Internet.nl testsuite zelf. Geen informatie over Apache-2.0 of licenties van Internet.nl code/vertalingen.*
+  - *Geen technische DANE rollover-inhoud over pre-publish methode in de aangeleverde brontekst.*
 
-## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (1)
+## UNGROUNDED — geen bron ondersteunt de claim (26)
 
-### `inet-toolbox-0001` — SKILL.md:26 *(§ Overzicht)*
-
-> De toolbox-wiki bevat implementatiegidsen voor alle standaarden die internet.nl test.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** inet-toolbox skill / toolbox-wiki
-
-- **PARTIALLY_SUPPORTED** (medium) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  > Quick access: DANE how-to, DKIM how-to, SPF how-to, DMARC how-to, Parked domain how-to
-  - *De bron toont how-to's voor DANE, DKIM, SPF, DMARC en parked domains. Internet.nl test ook DNSSEC, IPv6, HTTPS/TLS en andere standaarden waarvoor geen how-to's zichtbaar zijn in deze README. De claim 'alle standaarden' is dus te sterk.*
-- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *De brontekst is de Hall of Fame pagina van internet.nl met een lijst van domeinen die 100% scoren. Er is geen informatie over een toolbox-wiki of implementatiegidsen.*
-
-## UNGROUNDED — geen bron ondersteunt de claim (25)
-
-### `inet-toolbox-0004` — SKILL.md:73 *(§ 1. DNSSEC instellen)*
-
-> Na het genereren van DNSSEC-sleutels in BIND 9 moet het DS-record gepubliceerd worden bij de domeinregistrar.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** DNSSEC / BIND 9
-
-- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *Geen informatie over DS-records of domeinregistrars in de brontekst.*
-- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *Geen inhoud over DS-records of domeinregistrars in de aangeleverde brontekst.*
-
-### `inet-toolbox-0006` — SKILL.md:155 *(§ 2. HTTPS/TLS configureren)*
-
-> De Nginx TLS-configuratie dient `ssl_protocols TLSv1.2 TLSv1.3` te gebruiken (NCSC-conform).
-
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** HTTPS/TLS / Nginx
-
-- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *Geen Nginx TLS-configuratie informatie in de brontekst.*
-- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *Geen inhoud over Nginx TLS-configuratie in de aangeleverde brontekst.*
-
-### `inet-toolbox-0008` — SKILL.md:166 *(§ 2. HTTPS/TLS configureren)*
-
-> Nginx HSTS-header moet `max-age=31536000; includeSubDomains` bevatten.
-
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** HTTPS/TLS / Nginx / HSTS
-
-- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *Geen informatie over HSTS-headers of max-age in de brontekst.*
-- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *Geen inhoud over Nginx HSTS-configuratie in de aangeleverde brontekst.*
-
-### `inet-toolbox-0009` — SKILL.md:197 *(§ 2. HTTPS/TLS configureren)*
-
-> Apache TLS-configuratie sluit SSLv3, TLSv1 en TLSv1.1 uit via `SSLProtocol all -SSLv3 -TLSv1 -TLSv1.1`.
-
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** HTTPS/TLS / Apache
-
-- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *Geen informatie over Apache TLS-configuratie in de brontekst.*
-- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *Geen inhoud over Apache TLS-configuratie in de aangeleverde brontekst.*
-
-### `inet-toolbox-0010` — SKILL.md:203 *(§ 2. HTTPS/TLS configureren)*
-
-> Apache HSTS-header moet `max-age=31536000; includeSubDomains` bevatten.
-
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** HTTPS/TLS / Apache / HSTS
-
-- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *Geen informatie over Apache HSTS-headers in de brontekst.*
-- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *Geen inhoud over Apache HSTS-configuratie in de aangeleverde brontekst.*
-
-### `inet-toolbox-0011` — SKILL.md:218 *(§ 3. DMARC gefaseerd uitrollen)*
-
-> DMARC wordt gefaseerd uitgerold: eerst p=none (monitor), dan p=quarantine met oplopende pct, dan p=reject.
-
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** DMARC
-
-- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *Geen informatie over DMARC-uitrol of policies in de brontekst.*
-- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *Geen inhoud over DMARC-uitrolstrategie in de aangeleverde brontekst. Er is alleen een verwijzing naar DMARC-how-to.md, maar de inhoud daarvan is niet aangeleverd.*
-
-### `inet-toolbox-0012` — SKILL.md:222 *(§ 3. DMARC gefaseerd uitrollen)*
-
-> In de monitor-fase van DMARC-uitrol wordt 2 tot 4 weken gewacht om rapporten te analyseren voordat de policy wordt aangescherpt.
-
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** DMARC
-
-- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *Geen informatie over DMARC monitor-fase of wachttijden in de brontekst.*
-- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *Geen inhoud over DMARC monitor-fase of wachttijden in de aangeleverde brontekst.*
-
-### `inet-toolbox-0013` — SKILL.md:245 *(§ 4. DKIM instellen)*
-
-> Een DKIM RSA-sleutelpaar heeft minimaal 2048 bits.
-
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** DKIM
-
-- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *Geen informatie over DKIM RSA-sleutellengte in de brontekst.*
-- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *Geen inhoud over DKIM sleutellengte in de aangeleverde brontekst.*
-
-### `inet-toolbox-0015` — SKILL.md:298 *(§ 5. SPF-record samenstellen)*
-
-> SPF mag maximaal 10 DNS-lookups bevatten; elke `include`, `a`, `mx` en `redirect` telt als 1 lookup.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** SPF
-
-- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *Geen informatie over SPF DNS-lookup limieten in de brontekst.*
-- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *Geen inhoud over SPF DNS-lookup limiet in de aangeleverde brontekst.*
-
-### `inet-toolbox-0016` — SKILL.md:300 *(§ 5. SPF-record samenstellen)*
-
-> SPF-records moeten eindigen met `-all` (fail) of `~all` (softfail).
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** SPF
-
-- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *Geen informatie over SPF -all of ~all in de brontekst.*
-- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *Geen inhoud over SPF -all of ~all in de aangeleverde brontekst.*
-
-### `inet-toolbox-0017` — SKILL.md:299 *(§ 5. SPF-record samenstellen)*
-
-> Gebruik `ip4`/`ip6` in SPF om DNS-lookups te besparen.
-
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** SPF
-
-- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *Geen informatie over SPF ip4/ip6 mechanismen in de brontekst.*
-- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *Geen inhoud over ip4/ip6 mechanismen in SPF in de aangeleverde brontekst.*
-
-### `inet-toolbox-0018` — SKILL.md:315 *(§ 6. DANE instellen)*
+### `inet-toolbox-0002` — SKILL.md:315 *(§ 6. DANE instellen)*
 
 > DANE vereist dat DNSSEC actief is op het MX-domein.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** DANE
 
 - **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *Geen informatie over DANE of DNSSEC-vereisten in de brontekst.*
+  - *Bron bevat geen technische informatie over DANE.*
 - **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *Geen inhoud over DANE-vereisten of DNSSEC-afhankelijkheid in de aangeleverde brontekst.*
+  - *De brontekst vermeldt DANE als onderwerp van een how-to, maar geeft geen technische vereisten over DNSSEC-afhankelijkheid.*
 
-### `inet-toolbox-0020` — SKILL.md:335 *(§ 6. DANE instellen)*
+### `inet-toolbox-0003` — SKILL.md:335 *(§ 6. DANE instellen)*
 
-> Bij DANE met hergebruik van dezelfde privésleutel hoeft het TLSA-record niet te veranderen bij certificaatvernieuwing.
+> Bij DANE met TLSA selector=1 (SPKI) en hergebruik van de privésleutel hoeft het TLSA-record niet te veranderen bij certificaatvernieuwing.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MAY  ·  **Scope:** DANE
+**Type:** normative_requirement  ·  **Modaliteit:** MAY  ·  **Scope:** DANE / TLSA
 
 - **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *Geen informatie over DANE certificaatvernieuwing of privésleutelhergebruik in de brontekst.*
+  - *Bron bevat geen technische informatie over DANE/TLSA.*
 - **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *Geen inhoud over DANE privésleutel hergebruik in de aangeleverde brontekst.*
+  - *Geen technische inhoud over TLSA selector=1 of sleutelhergebruik in de aangeleverde brontekst.*
 
-### `inet-toolbox-0021` — SKILL.md:336 *(§ 6. DANE instellen)*
+### `inet-toolbox-0004` — SKILL.md:336 *(§ 6. DANE instellen)*
 
-> Bij DANE met een nieuwe sleutel moet het TLSA-record worden bijgewerkt VOOR de certificaatvernieuwing.
+> Bij DANE met een nieuwe privésleutel moet het TLSA-record worden bijgewerkt VOOR de certificaatvernieuwing.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** DANE
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** DANE / TLSA
 
 - **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *Geen informatie over DANE TLSA-record updates bij sleutelwisseling in de brontekst.*
+  - *Bron bevat geen technische informatie over DANE/TLSA.*
 - **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *Geen inhoud over TLSA-update timing bij certificaatvernieuwing in de aangeleverde brontekst.*
+  - *Geen technische inhoud over TLSA-record bijwerken bij certificaatvernieuwing in de aangeleverde brontekst.*
 
-### `inet-toolbox-0024` — reference.md:30 *(§ DNSSEC - geavanceerde configuratie)*
+### `inet-toolbox-0005` — SKILL.md:298 *(§ 5. SPF-record samenstellen)*
 
-> ZSK rollover wordt aanbevolen elke 3 maanden.
+> SPF-records mogen maximaal 10 DNS-lookups bevatten; elke `include`, `a`, `mx` en `redirect` telt als 1 lookup.
 
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** DNSSEC / key rollover
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** SPF
 
 - **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *Geen informatie over ZSK rollover-intervallen in de brontekst.*
+  - *Bron bevat geen technische informatie over SPF.*
 - **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *Geen inhoud over ZSK rollover-interval in de aangeleverde brontekst.*
+  - *Geen technische SPF-inhoud over DNS-lookup limieten in de aangeleverde brontekst.*
 
-### `inet-toolbox-0025` — reference.md:39 *(§ DNSSEC - geavanceerde configuratie)*
+### `inet-toolbox-0006` — SKILL.md:300 *(§ 5. SPF-record samenstellen)*
 
-> KSK rollover wordt aanbevolen jaarlijks.
-
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** DNSSEC / key rollover
-
-- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *Geen informatie over KSK rollover-intervallen in de brontekst.*
-- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *Geen inhoud over KSK rollover-interval in de aangeleverde brontekst.*
-
-### `inet-toolbox-0026` — reference.md:44 *(§ DNSSEC - geavanceerde configuratie)*
-
-> Bij KSK rollover moet het nieuwe DS-record bij de registrar gepubliceerd worden (naast het oude) voordat de DNSKEY RRset met de nieuwe KSK wordt ondertekend.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** DNSSEC / KSK rollover
-
-- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *Geen informatie over KSK rollover-procedure of DS-records in de brontekst.*
-- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *Geen inhoud over KSK rollover-procedure in de aangeleverde brontekst.*
-
-### `inet-toolbox-0027` — reference.md:59 *(§ DNSSEC - geavanceerde configuratie)*
-
-> ECDSAP256SHA256 (algoritme 13) is het aanbevolen algoritme voor nieuwe DNSSEC-zones vanwege compacte handtekeningen, brede ondersteuning en goede prestaties.
-
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** DNSSEC / algoritme-keuze
-
-- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *Geen informatie over ECDSAP256SHA256 of aanbevolen DNSSEC-algoritmen in de brontekst.*
-- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *Geen inhoud over ECDSAP256SHA256 als aanbevolen algoritme in de aangeleverde brontekst.*
-
-### `inet-toolbox-0031` — reference.md:160 *(§ E-mailbeveiliging - geavanceerde configuratie)*
-
-> Postfix `smtp_dns_support_level = dnssec` is vereist voor DANE-ondersteuning bij uitgaand SMTP.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** DANE / Postfix TLS
-
-- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *Geen informatie over Postfix smtp_dns_support_level in de brontekst.*
-- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *Geen inhoud over Postfix smtp_dns_support_level in de aangeleverde brontekst.*
-
-### `inet-toolbox-0032` — reference.md:142 *(§ E-mailbeveiliging - geavanceerde configuratie)*
-
-> Postfix TLS sluit SSLv2, SSLv3, TLSv1 en TLSv1.1 uit via `smtpd_tls_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1`.
-
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** HTTPS/TLS / Postfix
-
-- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *Geen informatie over Postfix TLS-protocollen of smtpd_tls_protocols in de brontekst.*
-- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *Geen inhoud over Postfix smtpd_tls_protocols in de aangeleverde brontekst.*
-
-### `inet-toolbox-0033` — reference.md:191 *(§ E-mailbeveiliging - geavanceerde configuratie)*
-
-> SPF-flattening is een oplossing wanneer je tegen de 10 DNS-lookup limiet aanloopt: vervang `include` door directe ip4:/ip6: regels.
+> SPF-records dienen te eindigen met `-all` (fail) of `~all` (softfail).
 
 **Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** SPF
 
 - **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *Geen informatie over SPF-flattening in de brontekst.*
+  - *Bron bevat geen technische informatie over SPF.*
 - **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *Geen inhoud over SPF-flattening in de aangeleverde brontekst.*
+  - *Geen technische SPF-inhoud over -all of ~all in de aangeleverde brontekst.*
 
-### `inet-toolbox-0034` — reference.md:239 *(§ DANE - geavanceerde configuratie)*
+### `inet-toolbox-0007` — SKILL.md:299 *(§ 5. SPF-record samenstellen)*
 
-> Bij DANE voor meerdere MX-servers moet elke MX een eigen TLSA-record hebben onder `_25._tcp.<mx-hostname>`.
+> Voor SPF wordt aanbevolen `ip4`/`ip6` te gebruiken om DNS-lookups te besparen.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** DANE / meerdere MX-servers
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** SPF
 
 - **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *Geen informatie over DANE met meerdere MX-servers in de brontekst.*
+  - *Bron bevat geen technische informatie over SPF.*
 - **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *Geen inhoud over DANE voor meerdere MX-servers in de aangeleverde brontekst.*
+  - *Geen technische SPF-inhoud over ip4/ip6 gebruik in de aangeleverde brontekst.*
 
-### `inet-toolbox-0035` — reference.md:230 *(§ DANE - geavanceerde configuratie)*
+### `inet-toolbox-0012` — SKILL.md:396 *(§ Veelvoorkomende problemen)*
 
-> Voor DANE-rollover kunnen meerdere TLSA-records tegelijk gepubliceerd worden: het huidige en het toekomstige certificaat naast elkaar.
+> DANE TLSA mismatch na certificaatvernieuwing kan worden voorkomen door SPKI (selector=1) te gebruiken en de privésleutel te hergebruiken, of door TLSA vooraf bij te werken.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MAY  ·  **Scope:** DANE / certificaatrollover
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** DANE / TLSA
 
 - **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *Geen informatie over DANE-rollover of meerdere TLSA-records in de brontekst.*
+  - *Bron bevat geen technische informatie over DANE/TLSA.*
 - **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *Geen inhoud over DANE-rollover met meerdere TLSA-records in de aangeleverde brontekst.*
+  - *Geen technische DANE/TLSA-inhoud over mismatch-preventie in de aangeleverde brontekst.*
 
-### `inet-toolbox-0036` — reference.md:281 *(§ IPv6 - geavanceerde configuratie)*
+### `inet-toolbox-0014` — SKILL.md:156 *(§ 2. HTTPS/TLS configureren)*
 
-> ICMPv6 moet geaccepteerd worden in de firewall (nftables) omdat het nodig is voor IPv6-werking.
+> De Nginx HTTPS-configuratie gebruikt TLSv1.2 en TLSv1.3 als toegestane protocollen (NCSC-conform).
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** HTTPS/TLS / Nginx
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Bron bevat geen Nginx/TLS-configuratie-informatie.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen technische Nginx TLS-configuratie-inhoud in de aangeleverde brontekst.*
+
+### `inet-toolbox-0015` — SKILL.md:158 *(§ 2. HTTPS/TLS configureren)*
+
+> De Nginx HTTPS-configuratie stelt `ssl_prefer_server_ciphers off` in.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** HTTPS/TLS / Nginx
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Bron bevat geen Nginx/TLS-configuratie-informatie.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen technische Nginx-inhoud over ssl_prefer_server_ciphers in de aangeleverde brontekst.*
+
+### `inet-toolbox-0016` — SKILL.md:160 *(§ 2. HTTPS/TLS configureren)*
+
+> De Nginx HTTPS-configuratie schakelt OCSP Stapling in via `ssl_stapling on` en `ssl_stapling_verify on`.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** HTTPS/TLS / Nginx
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Bron bevat geen Nginx/TLS-configuratie-informatie.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen technische Nginx-inhoud over OCSP Stapling in de aangeleverde brontekst.*
+
+### `inet-toolbox-0017` — SKILL.md:166 *(§ 2. HTTPS/TLS configureren)*
+
+> De aanbevolen HSTS-header voor Nginx is `Strict-Transport-Security: max-age=31536000; includeSubDomains`.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** HTTPS/TLS / HSTS
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Bron bevat geen HSTS-configuratie-informatie.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen technische inhoud over HSTS-headers in de aangeleverde brontekst.*
+
+### `inet-toolbox-0018` — SKILL.md:197 *(§ 2. HTTPS/TLS configureren)*
+
+> Apache HTTPS-configuratie schakelt SSLv3, TLSv1 en TLSv1.1 uit via `SSLProtocol all -SSLv3 -TLSv1 -TLSv1.1`.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** HTTPS/TLS / Apache
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Bron bevat geen Apache/TLS-configuratie-informatie.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen technische Apache TLS-configuratie-inhoud in de aangeleverde brontekst.*
+
+### `inet-toolbox-0019` — SKILL.md:199 *(§ 2. HTTPS/TLS configureren)*
+
+> Apache HTTPS-configuratie stelt `SSLHonorCipherOrder off` in.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** HTTPS/TLS / Apache
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Bron bevat geen Apache/TLS-configuratie-informatie.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen technische Apache-inhoud over SSLHonorCipherOrder in de aangeleverde brontekst.*
+
+### `inet-toolbox-0022` — reference.md:30 *(§ DNSSEC - geavanceerde configuratie)*
+
+> DNSSEC ZSK rollover wordt aanbevolen elke 3 maanden.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** DNSSEC / ZSK rollover
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Bron bevat geen informatie over DNSSEC ZSK rollover.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen technische DNSSEC-inhoud over ZSK rollover frequentie in de aangeleverde brontekst.*
+
+### `inet-toolbox-0023` — reference.md:39 *(§ DNSSEC - geavanceerde configuratie)*
+
+> DNSSEC KSK rollover wordt aanbevolen jaarlijks.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** DNSSEC / KSK rollover
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Bron bevat geen informatie over DNSSEC KSK rollover.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen technische DNSSEC-inhoud over KSK rollover frequentie in de aangeleverde brontekst.*
+
+### `inet-toolbox-0024` — reference.md:35 *(§ DNSSEC - geavanceerde configuratie)*
+
+> Bij ZSK rollover moet na het genereren van de nieuwe sleutel gewacht worden tot de oude TTL verlopen is (24-48 uur) voordat met de nieuwe sleutel ondertekend wordt.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** DNSSEC / ZSK rollover
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Bron bevat geen informatie over DNSSEC ZSK rollover procedures.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen technische DNSSEC-inhoud over ZSK rollover procedure in de aangeleverde brontekst.*
+
+### `inet-toolbox-0025` — reference.md:44 *(§ DNSSEC - geavanceerde configuratie)*
+
+> Bij KSK rollover moet het DS-record van de nieuwe KSK bij de registrar worden gepubliceerd naast het oude voordat de DNSKEY RRset met de nieuwe KSK wordt ondertekend.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** DNSSEC / KSK rollover
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Bron bevat geen informatie over DNSSEC KSK rollover procedures.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen technische DNSSEC-inhoud over KSK rollover en DS-records in de aangeleverde brontekst.*
+
+### `inet-toolbox-0026` — reference.md:59 *(§ DNSSEC - geavanceerde configuratie)*
+
+> ECDSAP256SHA256 (algoritme 13) is het aanbevolen DNSSEC-algoritme voor nieuwe zones vanwege compacte handtekeningen, brede ondersteuning en goede prestaties.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** DNSSEC / algoritme-keuze
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Bron bevat geen informatie over DNSSEC algoritme-keuze.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen technische DNSSEC-inhoud over algoritme-aanbevelingen in de aangeleverde brontekst.*
+
+### `inet-toolbox-0030` — reference.md:89 *(§ HTTPS/TLS - geavanceerde configuratie)*
+
+> Mozilla SSL Configuration Generator adviseert 'Intermediate' voor de beste balans tussen beveiliging en compatibiliteit.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** HTTPS/TLS
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Bron bevat geen informatie over Mozilla SSL Configuration Generator.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen inhoud over Mozilla SSL Configuration Generator in de aangeleverde brontekst.*
+
+### `inet-toolbox-0031` — reference.md:153 *(§ E-mailbeveiliging - geavanceerde configuratie)*
+
+> Postfix uitgaand TLS gebruikt `smtp_tls_security_level = dane` voor DANE-validatie.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** Postfix / DANE / TLS
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Bron bevat geen Postfix/DANE/TLS-configuratie-informatie.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen technische Postfix/DANE-inhoud in de aangeleverde brontekst.*
+
+### `inet-toolbox-0032` — reference.md:160 *(§ E-mailbeveiliging - geavanceerde configuratie)*
+
+> Postfix DANE vereist `smtp_dns_support_level = dnssec`.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Postfix / DANE
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Bron bevat geen Postfix/DANE-configuratie-informatie.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen technische Postfix/DANE-inhoud over smtp_dns_support_level in de aangeleverde brontekst.*
+
+### `inet-toolbox-0033` — reference.md:142 *(§ E-mailbeveiliging - geavanceerde configuratie)*
+
+> Postfix TLS-configuratie sluit SSLv2, SSLv3, TLSv1 en TLSv1.1 uit voor zowel inkomend als uitgaand verkeer.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** Postfix / TLS
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Bron bevat geen Postfix/TLS-configuratie-informatie.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen technische Postfix TLS-configuratie-inhoud in de aangeleverde brontekst.*
+
+### `inet-toolbox-0034` — reference.md:189 *(§ E-mailbeveiliging - geavanceerde configuratie)*
+
+> SPF-flattening is een oplossing wanneer het aantal DNS-lookups de limiet van 10 overschrijdt: IP-adressen direct opnemen of subdomeinen gebruiken.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** SPF
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Bron bevat geen informatie over SPF-flattening.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen technische SPF-inhoud over flattening in de aangeleverde brontekst.*
+
+### `inet-toolbox-0035` — reference.md:239 *(§ DANE - geavanceerde configuratie)*
+
+> Bij DANE voor meerdere MX-servers moet elk MX-domein een eigen TLSA-record hebben onder `_25._tcp.<mx-hostname>`.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** DANE / meerdere MX
+
+- **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
+  - *Bron bevat geen informatie over DANE voor meerdere MX-servers.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *Geen technische DANE/TLSA-inhoud over meerdere MX-servers in de aangeleverde brontekst.*
+
+### `inet-toolbox-0037` — reference.md:282 *(§ IPv6 - geavanceerde configuratie)*
+
+> ICMPv6 moet worden toegestaan in de firewall omdat het nodig is voor IPv6.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** IPv6 / firewall
 
 - **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *Geen informatie over IPv6, ICMPv6 of nftables in de brontekst.*
+  - *Bron bevat geen informatie over IPv6 firewall-configuratie.*
 - **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *Geen inhoud over ICMPv6 of nftables in de aangeleverde brontekst.*
+  - *Geen technische IPv6/firewall-inhoud over ICMPv6 in de aangeleverde brontekst.*
 
-### `inet-toolbox-0037` — reference.md:122 *(§ HTTPS/TLS - geavanceerde configuratie)*
+### `inet-toolbox-0038` — reference.md:122 *(§ HTTPS/TLS - geavanceerde configuratie)*
 
-> Let's Encrypt wildcard-certificaten vereisen een DNS-challenge (`--preferred-challenges dns`).
+> Let's Encrypt wildcard-certificaten vereisen een DNS-challenge.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** HTTPS/TLS / Let's Encrypt
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** Let's Encrypt / wildcard
 
 - **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *Geen informatie over Let's Encrypt wildcard-certificaten of DNS-challenges in de brontekst.*
+  - *Bron bevat geen informatie over Let's Encrypt wildcard-certificaten.*
 - **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *Geen inhoud over Let's Encrypt wildcard-certificaten of DNS-challenge in de aangeleverde brontekst.*
+  - *Geen technische inhoud over Let's Encrypt wildcard-certificaten in de aangeleverde brontekst.*
 
 ## GROUNDED — minstens één bron ondersteunt de claim (1)
 
 <details>
 <summary>Klap uit voor alle GROUNDED claims</summary>
 
-### `inet-toolbox-0038` — SKILL.md:385 *(§ Repositories)*
+### `inet-toolbox-0020` — SKILL.md:385 *(§ Repositories)*
 
 > De toolbox-wiki is gepubliceerd onder de CC-BY-4.0 licentie.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** toolbox-wiki / licentie
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** toolbox-wiki
 
 - **SUPPORTED** (medium) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
   > LICENSE-CC-BY-4.0.txt
-  - *De repository bevat een bestand genaamd LICENSE-CC-BY-4.0.txt, wat sterk impliceert dat de CC-BY-4.0 licentie van toepassing is. De bestandsnaam is geen expliciete verklaring, maar is voldoende directe aanwijzing. Confidence medium omdat de volledige licentietekst niet is weergegeven.*
+  - *De repository bevat een bestand genaamd LICENSE-CC-BY-4.0.txt, wat sterk suggereert dat de licentie CC-BY-4.0 is. De exacte licentietekst is niet aangeleverd, maar de bestandsnaam is een directe aanwijzing.*
+- **SOURCE_UNAVAILABLE** (high) — [https://raw.githubusercontent.com/internetstandards/toolbox-wiki/main/LICENSE](https://raw.githubusercontent.com/internetstandards/toolbox-wiki/main/LICENSE)
+  - *Bron status: unreachable*
+- **SOURCE_UNAVAILABLE** (high) — [https://raw.githubusercontent.com/internetstandards/toolbox-wiki/master/LICENSE](https://raw.githubusercontent.com/internetstandards/toolbox-wiki/master/LICENSE)
+  - *Bron status: unreachable*
 - **NOT_FOUND** (high) — [https://internet.nl/halloffame/](https://internet.nl/halloffame/)
-  - *Geen informatie over licenties van de toolbox-wiki in de brontekst.*
+  - *Bron bevat geen licentie-informatie over de toolbox-wiki.*
 
 </details>

--- a/skills/inet-web/audit.md
+++ b/skills/inet-web/audit.md
@@ -7,109 +7,114 @@
 
 | Status | Aantal | % |
 |--------|--------|---|
-| UNSUPPORTED_ASSERTION | 23 | 43% |
+| UNSUPPORTED_ASSERTION | 21 | 48% |
 | CONTRADICTED | 0 | 0% |
-| PARTIALLY_GROUNDED | 6 | 11% |
-| UNGROUNDED | 22 | 42% |
+| PARTIALLY_GROUNDED | 7 | 16% |
+| UNGROUNDED | 15 | 34% |
 | NO_SOURCE | 0 | 0% |
 | UNVERIFIABLE | 0 | 0% |
 | KNOWN_DISCREPANCY | 0 | 0% |
-| GROUNDED | 2 | 4% |
+| GROUNDED | 1 | 2% |
 
-*Geverifieerd met sonnet, 9 calls, $0.9819.*
+*Geverifieerd met sonnet, 10 calls, $0.9982.*
 
-## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (23)
+## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (21)
 
 ### `inet-web-0002` — SKILL.md:27 *(§ Overzicht)*
 
 > Alle door internet.nl geteste standaarden staan op de pas-toe-of-leg-uit-lijst van Forum Standaardisatie.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl / Forum Standaardisatie
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Forum Standaardisatie / internet.nl
+
+<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
   - *De bron maakt geen melding van Forum Standaardisatie of de pas-toe-of-leg-uit-lijst.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *RFC 6797 bevat geen informatie over Forum Standaardisatie of de pas-toe-of-leg-uit-lijst.*
+  - *De claim gaat over het Forum Standaardisatie en de pas-toe-of-leg-uit-lijst. RFC 6797 behandelt dit niet.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
+  - *De brontekst is een navigatiepagina van Forum Standaardisatie zonder inhoudelijke details over welke specifieke standaarden op de 'pas-toe-of-leg-uit'-lijst staan of over de relatie met internet.nl. Er is geen informatie over internet.nl of de geteste standaarden in de aangeleverde tekst.*
+</details>
 
-### `inet-web-0003` — SKILL.md:43 *(§ 1. IPv6)*
+### `inet-web-0003` — SKILL.md:42 *(§ 1. IPv6)*
 
-> Internet.nl test op aanwezigheid van een AAAA-record voor het domein.
+> Internet.nl test of een AAAA-record aanwezig is voor het domein.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl IPv6-test
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
-  - *De bron noemt IPv6 als testonderdeel maar gaat niet in op specifieke subtests zoals AAAA-records.*
+  - *De bron beschrijft niet op detailniveau welke subtests worden uitgevoerd binnen de IPv6-test. AAAA-records worden niet vermeld.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *RFC 6797 gaat over HSTS, niet over IPv6 of AAAA-records.*
+  - *De claim gaat over de IPv6-test van internet.nl (AAAA-records). RFC 6797 gaat over HSTS, niet over IPv6.*
 
-### `inet-web-0005` — SKILL.md:45 *(§ 1. IPv6)*
+### `inet-web-0005` — SKILL.md:44 *(§ 1. IPv6)*
 
 > Internet.nl test of nameservers bereikbaar zijn via IPv6.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl IPv6-test
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
-  - *De bron vermeldt geen test op IPv6-bereikbaarheid van nameservers.*
+  - *De bron noemt geen subtest over IPv6-bereikbaarheid van nameservers.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *RFC 6797 gaat over HSTS, niet over IPv6-bereikbaarheid van nameservers.*
+  - *De claim gaat over de IPv6-bereikbaarheidstest van nameservers via internet.nl. Buiten scope van RFC 6797.*
 
 ### `inet-web-0007` — SKILL.md:69 *(§ 2. DNSSEC)*
 
-> Internet.nl test of er een DS-record aanwezig is bij de registrar.
+> Internet.nl test of een DS-record aanwezig is bij de registrar.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl DNSSEC-test
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
-  - *De bron vermeldt geen specifieke subtest op DS-records bij de registrar.*
+  - *DS-records of registrar-gerelateerde subtests worden niet vermeld in de bron.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *RFC 6797 gaat over HSTS, niet over DS-records bij registrars.*
+  - *De claim gaat over DS-records en DNSSEC-registrar-configuratie. Buiten scope van RFC 6797.*
 
 ### `inet-web-0008` — SKILL.md:70 *(§ 2. DNSSEC)*
 
-> Internet.nl test op geldige RRSIG-handtekeningen en correcte ketenvalidatie (trust chain) bij DNSSEC.
+> Internet.nl test op geldige RRSIG-handtekeningen en correcte ketenvalidatie (trust chain) voor DNSSEC.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl DNSSEC-test
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
-  - *De bron vermeldt geen details over RRSIG-handtekeningen of ketenvalidatie.*
+  - *RRSIG-handtekeningen en trust chain validatie worden niet vermeld in de bron.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *RFC 6797 gaat over HSTS, niet over DNSSEC RRSIG-handtekeningen of ketenvalidatie.*
+  - *De claim gaat over RRSIG-handtekeningen en DNSSEC trust chain validatie. Buiten scope van RFC 6797.*
 
-### `inet-web-0010` — SKILL.md:96 *(§ 3. HTTPS / TLS)*
-
-> TLS 1.0/1.1 geeft een phase-out waarschuwing bij internet.nl; SSL 2.0/3.0 is een harde fout.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl TLS-test
-
-- **NOT_FOUND** (high) — [https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS](https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS)
-  - *De brontekst bevat geen informatie over TLS 1.0/1.1 phase-out waarschuwingen of SSL 2.0/3.0 fouten bij internet.nl.*
-
-### `inet-web-0012` — SKILL.md:95 *(§ 3. HTTPS / TLS)*
+### `inet-web-0010` — SKILL.md:95 *(§ 3. HTTPS / TLS)*
 
 > Internet.nl test op HTTPS bereikbaarheid en redirect van HTTP naar HTTPS.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl TLS-test
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl HTTPS/TLS-test
 
 - **NOT_FOUND** (high) — [https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS](https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS)
-  - *De brontekst bevat geen informatie over HTTPS-bereikbaarheid of HTTP-naar-HTTPS-redirects.*
+  - *De brontekst bevat geen informatie over internet.nl HTTPS-bereikbaarheid of redirects.*
+
+### `inet-web-0011` — SKILL.md:96 *(§ 3. HTTPS / TLS)*
+
+> TLS 1.0/1.1 geeft een phase-out waarschuwing bij internet.nl; SSL 2.0/3.0 is een harde fout.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl HTTPS/TLS-test
+
+- **NOT_FOUND** (high) — [https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS](https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS)
+  - *De brontekst bevat geen informatie over TLS 1.0/1.1 phase-out of SSL 2.0/3.0 fouten bij internet.nl.*
 
 ### `inet-web-0013` — SKILL.md:98 *(§ 3. HTTPS / TLS)*
 
 > Internet.nl test op een geldig certificaat (keten, geldigheid, hostnaam).
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl TLS-test
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl HTTPS/TLS-test
 
 - **NOT_FOUND** (high) — [https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS](https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS)
-  - *De brontekst bevat geen informatie over certificaatvalidatie, keten, geldigheid of hostnaam.*
+  - *De brontekst bevat geen informatie over certificaatvalidatie of internet.nl testmethodiek.*
 
 ### `inet-web-0014` — SKILL.md:99 *(§ 3. HTTPS / TLS)*
 
-> Internet.nl test OCSP stapling als niet-scorende melding.
+> OCSP stapling wordt door internet.nl getest als niet-scorende melding.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl TLS-test
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl HTTPS/TLS-test
 
 - **NOT_FOUND** (high) — [https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS](https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS)
-  - *De brontekst bevat geen informatie over OCSP stapling.*
+  - *De brontekst bevat geen informatie over OCSP stapling of internet.nl testscores.*
 
 ### `inet-web-0016` — SKILL.md:204 *(§ 5. Security headers)*
 
@@ -118,9 +123,9 @@
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl security headers-test
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
-  - *De bron vermeldt 'Security options' maar specificeert niet welke headers getest worden.*
+  - *Content-Security-Policy wordt niet apart vermeld. De bron noemt alleen 'Security options' als categorie.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *RFC 6797 gaat over HSTS, niet over Content-Security-Policy headers.*
+  - *De claim gaat over de Content-Security-Policy header. RFC 6797 behandelt alleen HSTS.*
 
 ### `inet-web-0017` — SKILL.md:205 *(§ 5. Security headers)*
 
@@ -129,9 +134,9 @@
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl security headers-test
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
-  - *De bron vermeldt 'Security options' maar specificeert niet welke headers getest worden.*
+  - *X-Frame-Options wordt niet vermeld in de bron.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *RFC 6797 gaat over HSTS, niet over X-Frame-Options headers.*
+  - *De claim gaat over de X-Frame-Options header. Buiten scope van RFC 6797.*
 
 ### `inet-web-0018` — SKILL.md:206 *(§ 5. Security headers)*
 
@@ -140,9 +145,9 @@
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl security headers-test
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
-  - *De bron vermeldt 'Security options' maar specificeert niet welke headers getest worden.*
+  - *X-Content-Type-Options wordt niet vermeld in de bron.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *RFC 6797 gaat over HSTS, niet over X-Content-Type-Options headers.*
+  - *De claim gaat over de X-Content-Type-Options header. Buiten scope van RFC 6797.*
 
 ### `inet-web-0019` — SKILL.md:207 *(§ 5. Security headers)*
 
@@ -151,9 +156,9 @@
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl security headers-test
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
-  - *De bron vermeldt 'Security options' maar specificeert niet welke headers getest worden.*
+  - *Referrer-Policy wordt niet vermeld in de bron.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *RFC 6797 gaat over HSTS, niet over Referrer-Policy headers.*
+  - *De claim gaat over de Referrer-Policy header. Buiten scope van RFC 6797.*
 
 ### `inet-web-0021` — SKILL.md:243 *(§ 6. security.txt)*
 
@@ -162,115 +167,93 @@
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl security.txt-test
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
-  - *De bron noemt security.txt in de kennisbank-sectie maar geeft geen details over vereiste velden of locatie.*
+  - *security.txt en de vereiste velden Contact en Expires worden niet vermeld in de bron.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *RFC 6797 gaat over HSTS, niet over security.txt of RFC 9116.*
+  - *De claim gaat over security.txt (RFC 9116) en de vereiste velden daarin. Buiten scope van RFC 6797.*
 
-### `inet-web-0024` — SKILL.md:276 *(§ 7. RPKI)*
+### `inet-web-0023` — SKILL.md:275 *(§ 7. RPKI)*
 
-> Internet.nl controleert of de ROA-status `valid` is (niet `invalid` of `unknown`).
+> Internet.nl test of een ROA-record aanwezig is voor het IP-adres van de webserver en of de ROA geldig is (valid, niet invalid of unknown).
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl RPKI-test
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
-  - *De bron vermeldt geen details over ROA-statussen (valid/invalid/unknown).*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *De brontekst betreft RFC 6797 (HSTS), niet RPKI of ROA-statussen.*
+  - *ROA-records en RPKI-validatiestatus worden niet op detailniveau beschreven. De bron noemt RPKI slechts als testcategorie.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *RFC 6797 gaat over HSTS; RPKI en ROA-records worden niet behandeld.*
 
-### `inet-web-0033` — reference.md:28 *(§ Aanbevolen cipher suites (NCSC))*
+### `inet-web-0029` — reference.md:28 *(§ Aanbevolen cipher suites (NCSC))*
 
-> Voor TLS 1.3 zijn alleen TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384 en TLS_CHACHA20_POLY1305_SHA256 beschikbaar en alle zijn goed.
+> Voor TLS 1.3 zijn alleen TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384 en TLS_CHACHA20_POLY1305_SHA256 beschikbaar als cipher suites.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** TLS 1.3 cipher suites
 
-- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
-  - *De bron vermeldt niets over TLS 1.3 cipher suites.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *De brontekst betreft RFC 6797 (HSTS), niet TLS 1.3 cipher suite specificaties.*
+- **OUT_OF_SCOPE** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron gaat over de internet.nl websitetest in het algemeen, niet over TLS 1.3 cipher suite specificaties.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *RFC 6797 behandelt TLS 1.3 cipher suites niet; de spec dateert van november 2012.*
 
-### `inet-web-0041` — reference.md:46 *(§ Renegotiation en OCSP (NCSC 2025-05))*
+### `inet-web-0036` — reference.md:46 *(§ Renegotiation en OCSP (NCSC 2025-05))*
 
-> Extended Master Secret (RFC 7627) is een aparte test geworden voor TLS 1.2; ontbreken telt als fout. Voor TLS 1.3 is het niet van toepassing.
+> Extended Master Secret (RFC 7627) is een aparte test geworden voor TLS 1.2; ontbreken telt als fout. Voor TLS 1.3 is dit niet van toepassing.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NCSC TLS Security Guidelines 2025-05 / Internet.nl v1.11.0
 
 <details><summary>3x NOT_FOUND (klap uit)</summary>
 
 - **NOT_FOUND** (high) — [https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS](https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS)
-  - *De brontekst bevat geen informatie over Extended Master Secret (RFC 7627) of TLS 1.2/1.3-specifieke testvereisten.*
+  - *De brontekst bevat geen inhoud over Extended Master Secret (RFC 7627) of TLS 1.2/1.3 specifieke tests.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/tls](https://www.forumstandaardisatie.nl/open-standaarden/tls)
-  - *Extended Master Secret (RFC 7627) wordt nergens in de brontekst genoemd. De bron beschrijft het functioneel toepassingsgebied en de lijststatus van TLS maar gaat niet in op specifieke testitems van Internet.nl.*
+  - *Extended Master Secret (RFC 7627) wordt niet vermeld in de brontekst.*
 - **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7627.txt](https://www.rfc-editor.org/rfc/rfc7627.txt)
-  - *RFC 7627 definieert de Extended Master Secret extensie zelf, maar bevat geen informatie over NCSC TLS Security Guidelines 2025-05, Internet.nl v1.11.0, teststructuur, of de classificatie als aparte test waarbij ontbreken als fout telt. De claim over hoe Internet.nl de EMS-test implementeert en categoriseert valt buiten de scope van deze RFC.*
+  - *De brontekst is RFC 7627 zelf (de technische specificatie van Extended Master Secret). De claim gaat over hoe Internet.nl v1.11.0 / NCSC TLS Security Guidelines 2025-05 EMS als aparte test classificeren en of ontbreken als fout telt. RFC 7627 bevat geen informatie over testclassificaties, scorebeleid of versie-specifieke testkaders van Internet.nl of NCSC. De constatering dat EMS niet van toepassing is op TLS 1.3 staat ook niet in deze RFC (TLS 1.3 bestaat überhaupt niet in dit document uit 2015). OUT_OF_SCOPE zou ook verdedigbaar zijn, maar de bron is niet per se de verkeerde categorie — hij dekt simpelweg de claim niet.*
 </details>
 
-### `inet-web-0042` — reference.md:47 *(§ Renegotiation en OCSP (NCSC 2025-05))*
+### `inet-web-0037` — reference.md:47 *(§ Renegotiation en OCSP (NCSC 2025-05))*
 
-> OCSP stapling wordt niet langer als fout gerekend wanneer het certificaat geen OCSP-endpoint bevat (AIA zonder OCSP URI); in dat geval wordt het als niet-getest gemeld.
+> OCSP stapling wordt niet langer als fout gerekend wanneer het certificaat zelf geen OCSP-endpoint bevat (AIA zonder OCSP URI); in dat geval wordt het als niet-getest gemeld.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NCSC TLS Security Guidelines 2025-05 / Internet.nl v1.11.0
 
 - **NOT_FOUND** (high) — [https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS](https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS)
-  - *De brontekst bevat geen informatie over OCSP stapling-gedrag bij ontbrekend OCSP-endpoint of AIA-velden.*
+  - *De brontekst bevat geen inhoud over OCSP stapling, AIA-extensies of testgedrag bij ontbrekende OCSP URI.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/tls](https://www.forumstandaardisatie.nl/open-standaarden/tls)
-  - *OCSP stapling, AIA, en de specifieke testlogica van Internet.nl v1.11.0 komen niet voor in de brontekst.*
+  - *OCSP stapling, AIA, of OCSP URI worden niet behandeld in de brontekst.*
 
-### `inet-web-0045` — reference.md:184 *(§ Preload-lijst)*
-
-> Het `preload` directive voor HSTS is onomkeerbaar op korte termijn.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** HSTS preload-lijst
-
-- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
-  - *De bron vermeldt niets over de onomkeerbaarheid van het preload directive.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *Het 'preload' directive en de onomkeerbaarheid ervan worden niet behandeld in RFC 6797.*
-
-### `inet-web-0046` — reference.md:211 *(§ Content-Security-Policy (CSP))*
+### `inet-web-0041` — reference.md:211 *(§ Content-Security-Policy (CSP))*
 
 > CSP `frame-ancestors` directive vervangt `X-Frame-Options`.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Content-Security-Policy / security headers
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Content-Security-Policy
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
-  - *De bron vermeldt niets over de relatie tussen CSP frame-ancestors en X-Frame-Options.*
+  - *CSP frame-ancestors als vervanging van X-Frame-Options wordt niet vermeld in de bron.*
 - **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *RFC 6797 gaat over HSTS en behandelt Content-Security-Policy, frame-ancestors noch X-Frame-Options.*
+  - *RFC 6797 behandelt Content-Security-Policy en frame-ancestors niet.*
 
-### `inet-web-0049` — reference.md:260 *(§ Hoe RPKI werkt)*
+### `inet-web-0043` — reference.md:260 *(§ Hoe RPKI werkt)*
 
-> Een ROA (Route Origin Authorisation) is een digitaal ondertekende verklaring die een IP-prefix koppelt aan een AS-nummer.
+> Een RPKI ROA (Route Origin Authorisation) is een digitaal ondertekende verklaring die een IP-prefix koppelt aan een AS-nummer.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** RPKI / BGP
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** RPKI
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
-  - *De bron vermeldt niets over ROA's of de koppeling van IP-prefixen aan AS-nummers.*
+  - *De definitie van een ROA als digitaal ondertekende verklaring die een IP-prefix koppelt aan een AS-nummer wordt niet vermeld in de bron.*
 - **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *RFC 6797 behandelt RPKI, ROA's en BGP niet.*
+  - *RFC 6797 behandelt RPKI en ROA niet; de bron gaat uitsluitend over HSTS.*
 
-### `inet-web-0050` — reference.md:264 *(§ Hoe RPKI werkt)*
+### `inet-web-0044` — reference.md:264 *(§ Hoe RPKI werkt)*
 
-> RPKI-validatiestatus kent drie waarden: `Valid`, `Invalid` en `NotFound`.
+> RPKI validatiestatus kent drie waarden: `Valid` (BGP-aankondiging komt overeen met een ROA), `Invalid` (conflicteert met een ROA) en `NotFound` (geen ROA gevonden).
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** RPKI / ROV
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** RPKI Route Origin Validation
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
-  - *De bron vermeldt niets over RPKI-validatiestatussen.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *RFC 6797 behandelt RPKI-validatiestatus niet.*
+  - *De drie RPKI validatiestatussen (Valid, Invalid, NotFound) worden niet vermeld in de bron.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *De bron is RFC 6797, die uitsluitend gaat over HTTP Strict Transport Security (HSTS). RPKI (Resource Public Key Infrastructure) en Route Origin Validation worden nergens in deze bron behandeld.*
 
-### `inet-web-0051` — reference.md:271 *(§ ROA aanmaken)*
-
-> ROA's worden aangemaakt in het RIPE NCC-portaal voor Europese netwerken via https://my.ripe.net.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** RPKI / RIPE NCC
-
-- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
-  - *De bron vermeldt niets over RIPE NCC of het aanmaken van ROA's.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *RFC 6797 behandelt ROA's, RIPE NCC noch my.ripe.net.*
-
-## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (6)
+## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (7)
 
 ### `inet-web-0001` — SKILL.md:26 *(§ Overzicht)*
 
@@ -279,12 +262,12 @@
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl websitetest
 
 - **PARTIALLY_SUPPORTED** (medium) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
-  > After you enter a domain name of a website, we will test if the website offers support for the modern Internet Standards below. IPv6 : reachable via modern address? DNSSEC : domain name signed? HTTPS : secure connection? Security options : security options set? RPKI : route authorisation?
-  - *De bron bevestigt IPv6, DNSSEC, HTTPS, Security options en RPKI. HSTS en security.txt worden niet expliciet als subtests genoemd in de bron (alleen 'Security options' als verzamelnaam).*
+  > After the test is finished, you are directed to a test report. The report contains an overall percentage score and results per test section and per subtest.
+  - *De bron noemt IPv6, DNSSEC, HTTPS, Security options en RPKI expliciet als testcategorieën. HSTS als aparte subtest en security.txt worden niet apart benoemd, maar vallen vermoedelijk onder 'Security options'. De specifieke opsomming 'HSTS, security headers, security.txt' staat niet letterlijk in de bron.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *RFC 6797 gaat uitsluitend over HSTS. Het beschrijft niet wat internet.nl test.*
+  - *Deze bron is RFC 6797 (HSTS-specificatie). De claim gaat over de internet.nl testtool en welke standaarden daarin getest worden. Dat onderwerp wordt niet behandeld in deze RFC.*
 
-### `inet-web-0004` — SKILL.md:44 *(§ 1. IPv6)*
+### `inet-web-0004` — SKILL.md:43 *(§ 1. IPv6)*
 
 > Internet.nl test of de webserver bereikbaar is via IPv6.
 
@@ -292,9 +275,9 @@
 
 - **PARTIALLY_SUPPORTED** (medium) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
   > IPv6 : reachable via modern address?
-  - *De bron bevestigt dat bereikbaarheid via IPv6 getest wordt, maar specificeert niet dat het om de webserver gaat.*
+  - *De bron bevestigt dat bereikbaarheid via IPv6 wordt getest, maar noemt niet expliciet de webserver als specifiek testobject.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *RFC 6797 gaat over HSTS, niet over IPv6-bereikbaarheid van webservers.*
+  - *De claim gaat over de IPv6-bereikbaarheidstest van internet.nl. Buiten scope van RFC 6797.*
 
 ### `inet-web-0006` — SKILL.md:68 *(§ 2. DNSSEC)*
 
@@ -304,67 +287,75 @@
 
 - **PARTIALLY_SUPPORTED** (medium) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
   > DNSSEC : domain name signed?
-  - *De bron bevestigt dat DNSSEC getest wordt (domein gesigneerd), maar specificeert niet expliciet dat het om de DNS-zone gaat.*
+  - *De bron bevestigt dat DNSSEC-ondertekening van het domein wordt getest, maar noemt niet specifiek het testen van de DNS-zone.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *RFC 6797 gaat over HSTS, niet over DNSSEC-zone-ondertekening.*
+  - *De claim gaat over de DNSSEC-test van internet.nl. RFC 6797 behandelt DNSSEC niet.*
 
-### `inet-web-0015` — SKILL.md:176 *(§ 4. HSTS)*
+### `inet-web-0015` — SKILL.md:175 *(§ 4. HSTS)*
 
-> Internet.nl vereist de `Strict-Transport-Security` header met een `max-age` van minimaal 31536000 (1 jaar).
+> Internet.nl test op aanwezigheid van de `Strict-Transport-Security` header en een `max-age` van minimaal 31536000 (1 jaar).
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** internet.nl HSTS-test
 
 - **PARTIALLY_SUPPORTED** (medium) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
   > The HSTS header field below stipulates that the HSTS Policy is to remain in effect for one year (there are approximately 31536000 seconds in a year), and the policy applies only to the domain of the HSTS Host issuing it: Strict-Transport-Security: max-age=31536000
-  - *RFC 6797 bevestigt dat 31536000 seconden overeenkomt met één jaar en geeft dit als voorbeeld, maar stelt geen minimumwaarde voor max-age verplicht. De eis dat internet.nl specifiek een minimum van 31536000 vereist staat niet in deze RFC — dat is een internet.nl-testbeleid, niet een RFC-vereiste.*
+  - *RFC 6797 bevestigt dat de Strict-Transport-Security header bestaat en dat 31536000 seconden één jaar is, en gebruikt dit als voorbeeldwaarde. De RFC specificeert echter geen minimale max-age waarde — dat is een internetstandaard-testcriterium van internet.nl zelf, niet iets dat RFC 6797 normatief vereist. De aanwezigheid van de header en het max-age-mechanisme worden ondersteund; de eis van 'minimaal 31536000' als testdrempel niet.*
 - **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
-  - *De bron noemt security options als testcategorie maar geeft geen details over HSTS-vereisten of max-age waarden.*
+  - *Strict-Transport-Security header en max-age vereisten worden niet vermeld in de bron.*
 
-### `inet-web-0023` — SKILL.md:275 *(§ 7. RPKI)*
+### `inet-web-0032` — reference.md:37 *(§ Certificaatvereisten)*
 
-> Internet.nl test RPKI door te controleren of er een geldig ROA-record aanwezig is voor het IP-adres van de webserver.
+> TLS-certificaten vereisen een geldige keten naar een vertrouwde root CA en de hostnaam in Subject Alternative Name (SAN).
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl RPKI-test
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** TLS certificaatvereisten
 
-- **PARTIALLY_SUPPORTED** (low) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
-  > RPKI : route authorisation?
-  - *De bron bevestigt dat RPKI getest wordt, maar vermeldt niet specifiek ROA-records of IP-adressen van de webserver.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *De brontekst betreft RFC 6797 (HSTS), niet RPKI of ROA-records. Geen relevante inhoud voor deze claim.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  > When connecting to a Known HSTS Host, the UA MUST terminate the connection [...] if there are any errors [...] with the underlying secure transport. For example, this includes any errors found in certificate validity checking [...] as well as via TLS server identity checking [RFC6125].
+  - *De bron bevestigt indirect dat certificaatketenvalidatie en host-identiteitscontrole vereist zijn (fouten leiden tot verbindingsafbreking), maar vermeldt Subject Alternative Name (SAN) niet expliciet. De eis over 'geldige keten naar vertrouwde root CA' wordt impliciet ondersteund via Section 8.4, maar SAN-vereiste staat niet in de bron.*
+- **OUT_OF_SCOPE** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron gaat over de internet.nl websitetest in het algemeen, niet over certificaatketen- of SAN-vereisten.*
 
-### `inet-web-0040` — reference.md:45 *(§ Renegotiation en OCSP (NCSC 2025-05))*
+### `inet-web-0038` — reference.md:173 *(§ Preload-lijst)*
 
-> Secure renegotiation (RFC 5746) blijft verplicht.
+> Voor HSTS preloading is een `max-age` van minimaal 31536000 vereist, samen met `includeSubDomains` en `preload` directive.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NCSC TLS Security Guidelines 2025-05 / Internet.nl v1.11.0
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** HSTS preload-lijst
 
-- **PARTIALLY_SUPPORTED** (medium) — [https://www.rfc-editor.org/rfc/rfc5746.txt](https://www.rfc-editor.org/rfc/rfc5746.txt)
-  > Servers SHOULD NOT allow clients to renegotiate without using this extension. Many servers can mitigate this attack simply by refusing to renegotiate at all.
-  - *RFC 5746 definieert het secure renegotiation mechanisme en stelt dat servers het MOETEN implementeren voor de initiële handshake ('even servers that do not support renegotiation MUST implement the minimal version of the extension described in this document for initial handshakes'). De RFC ondersteunt de technische basis van de claim, maar de claim verwijst specifiek naar NCSC TLS Security Guidelines 2025-05 / Internet.nl v1.11.0 als normatieve context. De RFC zelf spreekt van SHOULD NOT (servers mogen renegotiatie toestaan mits via de extensie), niet van een absolute verplichting. De verplichtstelling als zodanig ('verplicht') is een beleidsinterpretatie die de RFC deels maar niet volledig dekt.*
-- **NOT_FOUND** (high) — [https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS](https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS)
-  - *De brontekst bevat geen informatie over secure renegotiation (RFC 5746).*
-- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/tls](https://www.forumstandaardisatie.nl/open-standaarden/tls)
-  - *De brontekst verwijst naar NCSC TLS-richtlijnen en Internet.nl als hulpmiddelen, maar bevat geen inhoudelijke specificaties over secure renegotiation (RFC 5746) of verplichtingen daaromtrent.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  > The HSTS header field below stipulates that the HSTS Policy is to remain in effect for one year (there are approximately 31536000 seconds in a year): Strict-Transport-Security: max-age=31536000
+  - *De bron bevestigt dat max-age=31536000 overeenkomt met één jaar en beschrijft includeSubDomains als optionele directive. Het 'preload' directive wordt echter nergens in RFC 6797 vermeld — dat is een latere toevoeging buiten deze spec. Daardoor is de claim over het preload-vereiste NIET_GEVONDEN in deze bron, maar het max-age-gedeelte en includeSubDomains worden wel ondersteund.*
+- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *HSTS preload-vereisten worden niet vermeld in de bron.*
 
-## UNGROUNDED — geen bron ondersteunt de claim (22)
+### `inet-web-0042` — reference.md:229 *(§ Verplichte velden)*
+
+> RFC 9116 definieert `Contact` en `Expires` als verplichte velden in security.txt; `Expires` moet in ISO 8601-formaat zijn en maximaal 1 jaar vooruit.
+
+**Type:** reference_claim  ·  **Modaliteit:** MUST  ·  **Scope:** security.txt / RFC 9116
+
+- **PARTIALLY_SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc9116.txt](https://www.rfc-editor.org/rfc/rfc9116.txt)
+  > This field MUST always be present in a "security.txt" file. [...] The "Expires" field [...] This field MUST always be present and MUST NOT appear more than once. [...] It is RECOMMENDED that the value of this field be less than a year into the future to avoid staleness.
+  - *Contact en Expires als verplichte velden worden volledig ondersteund. Het ISO 8601-formaat voor Expires is ook correct (via RFC 3339 die de Internet-profielen van ISO 8601 definieert). Echter: de claim stelt dat Expires 'maximaal 1 jaar vooruit' MOET zijn, terwijl de RFC dit slechts RECOMMENDS ('It is RECOMMENDED that the value of this field be less than a year into the future'). Dat is een verschil in vereistingsniveau: RECOMMENDED vs. de MUST die de claim impliceert.*
+
+## UNGROUNDED — geen bron ondersteunt de claim (15)
 
 ### `inet-web-0009` — SKILL.md:89 *(§ 3. HTTPS / TLS)*
 
 > Internet.nl vereist TLS 1.2 of 1.3 met sterke cipher suites.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** internet.nl TLS-test
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** internet.nl HTTPS/TLS-test
 
 - **NOT_FOUND** (high) — [https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS](https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS)
-  - *De brontekst bevat alleen een pagina-layout met downloadlinks voor TLS-richtlijnen. Er staat geen inhoudelijke informatie over internet.nl-testvereisten of specifieke TLS-versies.*
+  - *De brontekst bevat alleen een pagina-listing van de NCSC TLS-richtlijnen documenten (PDF links, data, errata). Er staat geen inhoudelijke informatie over internet.nl vereisten of TLS-versies.*
 
-### `inet-web-0011` — SKILL.md:97 *(§ 3. HTTPS / TLS)*
+### `inet-web-0012` — SKILL.md:97 *(§ 3. HTTPS / TLS)*
 
 > Internet.nl test op sterke cipher suites; RC4, 3DES, NULL en export ciphers zijn niet toegestaan.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** internet.nl TLS-test / cipher suites
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** internet.nl HTTPS/TLS-test
 
 - **NOT_FOUND** (high) — [https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS](https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS)
-  - *De brontekst bevat geen informatie over cipher suite vereisten of verboden ciphers.*
+  - *De brontekst bevat geen inhoudelijke specificaties over cipher suites of verboden algoritmen.*
 
 ### `inet-web-0022` — SKILL.md:245 *(§ 6. security.txt)*
 
@@ -373,241 +364,160 @@
 **Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** security.txt / RFC 9116
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
-  - *De bron vermeldt niets over PGP-ondertekening van security.txt.*
+  - *PGP-ondertekening van security.txt wordt niet vermeld in de bron.*
 - **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *RFC 6797 gaat over HSTS, niet over PGP-ondertekening van security.txt.*
+  - *De claim gaat over PGP-ondertekening van security.txt conform RFC 9116. Buiten scope van RFC 6797.*
+
+### `inet-web-0024` — SKILL.md:306 *(§ Veelvoorkomende problemen)*
+
+> security.txt heeft `Expires` als verplicht veld; een verlopen datum geeft een fout bij internet.nl.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** internet.nl security.txt-test
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *Expires als verplicht veld voor security.txt wordt niet vermeld in de bron.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *RFC 6797 gaat over HSTS; security.txt en het Expires-veld worden niet behandeld.*
 
 ### `inet-web-0025` — reference.md:13 *(§ Aanbevolen cipher suites (NCSC))*
 
-> NCSC adviseert TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 als aanbevolen (voorkeur) cipher suite voor TLS 1.2.
+> Het NCSC adviseert TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 en TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 als voorkeurs-cipher suites voor TLS 1.2.
 
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** NCSC TLS Security Guidelines / TLS 1.2 cipher suites
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** NCSC TLS Security Guidelines / TLS 1.2
 
-- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
-  - *De bron vermeldt niets over NCSC TLS-richtlijnen of specifieke cipher suites.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *De brontekst betreft RFC 6797 (HSTS), niet NCSC TLS-richtlijnen of cipher suites.*
+- **OUT_OF_SCOPE** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron gaat over de internet.nl websitetest in het algemeen, niet over NCSC TLS Security Guidelines of specifieke cipher suites.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *RFC 6797 specificeert geen cipher suites; NCSC TLS-richtlijnen worden niet behandeld.*
 
-### `inet-web-0026` — reference.md:14 *(§ Aanbevolen cipher suites (NCSC))*
+### `inet-web-0026` — reference.md:17 *(§ Aanbevolen cipher suites (NCSC))*
 
-> NCSC adviseert TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 als aanbevolen (voorkeur) cipher suite voor TLS 1.2.
+> Het NCSC adviseert TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 en TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 als voorkeurs-cipher suites voor TLS 1.2.
 
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** NCSC TLS Security Guidelines / TLS 1.2 cipher suites
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** NCSC TLS Security Guidelines / TLS 1.2
 
-- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
-  - *De bron vermeldt niets over NCSC TLS-richtlijnen of specifieke cipher suites.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *De brontekst betreft RFC 6797 (HSTS), niet NCSC TLS-richtlijnen of cipher suites.*
+- **OUT_OF_SCOPE** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron gaat over de internet.nl websitetest in het algemeen, niet over NCSC TLS Security Guidelines of ChaCha20-gebaseerde cipher suites.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *RFC 6797 specificeert geen cipher suites; ChaCha20-POLY1305 wordt niet vermeld.*
 
-### `inet-web-0027` — reference.md:15 *(§ Aanbevolen cipher suites (NCSC))*
+### `inet-web-0027` — reference.md:21 *(§ Aanbevolen cipher suites (NCSC))*
 
-> NCSC adviseert TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 als aanbevolen (voorkeur) cipher suite voor TLS 1.2.
+> TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256 en TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 zijn voldoende cipher suites voor TLS 1.2 (niet voorkeur).
 
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** NCSC TLS Security Guidelines / TLS 1.2 cipher suites
+**Type:** normative_requirement  ·  **Modaliteit:** MAY  ·  **Scope:** NCSC TLS Security Guidelines / TLS 1.2
 
-- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
-  - *De bron vermeldt niets over NCSC TLS-richtlijnen of specifieke cipher suites.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *De brontekst betreft RFC 6797 (HSTS), niet NCSC TLS-richtlijnen of cipher suites.*
+- **OUT_OF_SCOPE** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron gaat over de internet.nl websitetest in het algemeen, niet over NCSC TLS Security Guidelines of CBC-gebaseerde cipher suites.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *RFC 6797 specificeert geen cipher suites of hun classificatie.*
 
-### `inet-web-0028` — reference.md:16 *(§ Aanbevolen cipher suites (NCSC))*
+### `inet-web-0028` — reference.md:25 *(§ Aanbevolen cipher suites (NCSC))*
 
-> NCSC adviseert TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 als aanbevolen (voorkeur) cipher suite voor TLS 1.2.
+> Cipher suites met RC4, 3DES, NULL, EXPORT, DES, MD5 en TLS_RSA_* zijn niet toegestaan (geen forward secrecy).
 
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** NCSC TLS Security Guidelines / TLS 1.2 cipher suites
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** NCSC TLS Security Guidelines
 
-- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
-  - *De bron vermeldt niets over NCSC TLS-richtlijnen of specifieke cipher suites.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *De brontekst betreft RFC 6797 (HSTS), niet NCSC TLS-richtlijnen of cipher suites.*
+- **OUT_OF_SCOPE** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron gaat over de internet.nl websitetest in het algemeen, niet over verboden cipher suites of NCSC TLS Security Guidelines.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *RFC 6797 verbiedt geen specifieke cipher suites; dit valt buiten de scope van de bron.*
 
-### `inet-web-0029` — reference.md:17 *(§ Aanbevolen cipher suites (NCSC))*
+### `inet-web-0030` — reference.md:35 *(§ Certificaatvereisten)*
 
-> NCSC adviseert TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 als aanbevolen (voorkeur) cipher suite voor TLS 1.2.
-
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** NCSC TLS Security Guidelines / TLS 1.2 cipher suites
-
-- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
-  - *De bron vermeldt niets over NCSC TLS-richtlijnen of specifieke cipher suites.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *De brontekst betreft RFC 6797 (HSTS), niet NCSC TLS-richtlijnen of cipher suites.*
-
-### `inet-web-0030` — reference.md:18 *(§ Aanbevolen cipher suites (NCSC))*
-
-> NCSC adviseert TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 als aanbevolen (voorkeur) cipher suite voor TLS 1.2.
-
-**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** NCSC TLS Security Guidelines / TLS 1.2 cipher suites
-
-- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
-  - *De bron vermeldt niets over NCSC TLS-richtlijnen of specifieke cipher suites.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *De brontekst betreft RFC 6797 (HSTS), niet NCSC TLS-richtlijnen of cipher suites.*
-
-### `inet-web-0031` — reference.md:25 *(§ Aanbevolen cipher suites (NCSC))*
-
-> Cipher suites met RC4, 3DES, NULL, EXPORT, DES of MD5 zijn niet toegestaan volgens NCSC.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** NCSC TLS Security Guidelines / cipher suites
-
-- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
-  - *De bron vermeldt niets over verboden cipher suites of NCSC-richtlijnen.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *De brontekst betreft RFC 6797 (HSTS), niet NCSC-richtlijnen over verboden cipher suites.*
-
-### `inet-web-0032` — reference.md:26 *(§ Aanbevolen cipher suites (NCSC))*
-
-> TLS_RSA_* cipher suites zijn niet toegestaan vanwege ontbreken van forward secrecy.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** NCSC TLS Security Guidelines / cipher suites
-
-- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
-  - *De bron vermeldt niets over TLS_RSA_* cipher suites of forward secrecy.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *De brontekst betreft RFC 6797 (HSTS), niet forward secrecy-vereisten of TLS_RSA_* cipher suites.*
-
-### `inet-web-0034` — reference.md:35 *(§ Certificaatvereisten)*
-
-> TLS-certificaten vereisen minimaal 2048-bit RSA of 256-bit ECDSA sleutellengte.
+> TLS-certificaten vereisen minimaal 2048-bit RSA of 256-bit ECDSA.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** TLS certificaatvereisten
 
-- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
-  - *De bron vermeldt niets over sleutellengtes voor TLS-certificaten.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *De brontekst betreft RFC 6797 (HSTS), niet sleutellengtes voor TLS-certificaten.*
+- **OUT_OF_SCOPE** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron gaat over de internet.nl websitetest in het algemeen, niet over minimale sleutellengtes voor TLS-certificaten.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *RFC 6797 stelt geen minimale sleutellengte-eisen voor certificaten.*
 
-### `inet-web-0035` — reference.md:36 *(§ Certificaatvereisten)*
+### `inet-web-0031` — reference.md:36 *(§ Certificaatvereisten)*
 
 > TLS-certificaten vereisen SHA-256 of hoger als hash-algoritme.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** TLS certificaatvereisten
 
-- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
-  - *De bron vermeldt niets over hash-algoritmen voor TLS-certificaten.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *De brontekst betreft RFC 6797 (HSTS), niet hash-algoritme-vereisten voor TLS-certificaten.*
+- **OUT_OF_SCOPE** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron gaat over de internet.nl websitetest in het algemeen, niet over hash-algoritme vereisten voor TLS-certificaten.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *RFC 6797 stelt geen hash-algoritme-eisen voor certificaten.*
 
-### `inet-web-0036` — reference.md:37 *(§ Certificaatvereisten)*
+### `inet-web-0033` — reference.md:44 *(§ Renegotiation en OCSP (NCSC 2025-05))*
 
-> TLS-certificaten vereisen een geldige keten naar een vertrouwde root CA.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** TLS certificaatvereisten
-
-- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
-  - *De bron vermeldt niets over certificaatketens of vertrouwde root CA's.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *De brontekst betreft RFC 6797 (HSTS). Hoewel HSTS vertrouwde certificaatketens veronderstelt, specificeert de RFC geen expliciete eis voor een geldige keten naar een vertrouwde root CA als certificaatvereiste.*
-
-### `inet-web-0037` — reference.md:38 *(§ Certificaatvereisten)*
-
-> De hostnaam moet aanwezig zijn in het Subject Alternative Name (SAN) veld van het TLS-certificaat.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** TLS certificaatvereisten
-
-- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
-  - *De bron vermeldt niets over Subject Alternative Name velden in certificaten.*
-- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *De brontekst betreft RFC 6797 (HSTS), niet Subject Alternative Name (SAN)-vereisten voor TLS-certificaten.*
-
-### `inet-web-0038` — reference.md:44 *(§ Renegotiation en OCSP (NCSC 2025-05))*
-
-> Met de NCSC TLS-richtlijnen van mei 2025 (geïmplementeerd in Internet.nl v1.11.0) is client-initiated renegotiation acceptabel mits het aantal beperkt blijft tot minder dan 10 per verbinding.
+> Met de NCSC TLS-richtlijnen van mei 2025 (geïmplementeerd in Internet.nl v1.11.0) is client-initiated renegotiation acceptabel mits de server het aantal renegotiations beperkt tot minder dan 10 per verbinding.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MAY  ·  **Scope:** NCSC TLS Security Guidelines 2025-05 / Internet.nl v1.11.0
 
 - **NOT_FOUND** (high) — [https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS](https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS)
-  - *De brontekst is een webpagina met uitsluitend downloadlinks naar PDF-documenten. De inhoud van de TLS-richtlijnen 2025-05 zelf is niet aangeleverd; claims over renegotiation-limieten kunnen hier niet worden geverifieerd.*
+  - *De brontekst is alleen de downloadpagina; de PDF-inhoud van de NCSC TLS-richtlijnen 2025-05 is niet aangeleverd. Er is geen tekst over client-initiated renegotiation beschikbaar.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/tls](https://www.forumstandaardisatie.nl/open-standaarden/tls)
-  - *De brontekst behandelt TLS algemeen (versies 1.2 en 1.3, toepassingsgebied, adoptieadviezen) maar bevat geen informatie over client-initiated renegotiation, NCSC TLS-richtlijnen van mei 2025, of Internet.nl v1.11.0.*
+  - *De brontekst betreft de Forum Standaardisatie pagina voor TLS in het algemeen. Er is geen informatie over client-initiated renegotiation, limieten daarvoor, of specifieke NCSC TLS-richtlijnen van mei 2025 of Internet.nl v1.11.0.*
 
-### `inet-web-0039` — reference.md:44 *(§ Renegotiation en OCSP (NCSC 2025-05))*
+### `inet-web-0034` — reference.md:44 *(§ Renegotiation en OCSP (NCSC 2025-05))*
 
-> Onbeperkte client renegotiation blijft een fout vanwege DoS-risico.
+> Onbeperkte client renegotiation blijft een fout (DoS-risico) bij internet.nl.
 
 **Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** NCSC TLS Security Guidelines 2025-05 / Internet.nl v1.11.0
 
 - **NOT_FOUND** (high) — [https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS](https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS)
-  - *De brontekst bevat geen inhoudelijke richtlijnen over client renegotiation of DoS-risico's.*
+  - *De brontekst bevat geen inhoudelijke specificaties over renegotiation-limieten of DoS-risico's.*
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/tls](https://www.forumstandaardisatie.nl/open-standaarden/tls)
-  - *De brontekst bevat geen informatie over client renegotiation, DoS-risico's in die context, of de specifieke NCSC/Internet.nl versie-scope van de claim.*
+  - *De brontekst bevat geen informatie over client renegotiation of DoS-risico's daarvan bij Internet.nl.*
 
-### `inet-web-0043` — reference.md:173 *(§ Preload-lijst)*
+### `inet-web-0035` — reference.md:45 *(§ Renegotiation en OCSP (NCSC 2025-05))*
 
-> HSTS preloading vereist een `max-age` van minimaal 31536000, de `includeSubDomains` directive én de `preload` directive.
+> Secure renegotiation (RFC 5746) blijft verplicht.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** HSTS preload-lijst / hstspreload.org
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NCSC TLS Security Guidelines 2025-05
 
-- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
-  - *De bron vermeldt niets over HSTS preloading of bijbehorende vereisten.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *RFC 6797 definieert HSTS maar beschrijft geen preload-vereisten. Het 'preload' directive wordt niet vermeld in deze spec. De minimale max-age van 31536000 voor preloading is een vereiste van hstspreload.org, niet van RFC 6797. De spec noemt wel max-age=31536000 als voorbeeld van een jaar, maar niet als preload-vereiste.*
+<details><summary>2x NOT_FOUND + 1x OUT_OF_SCOPE (klap uit)</summary>
 
-### `inet-web-0044` — reference.md:171 *(§ Preload-lijst)*
+- **NOT_FOUND** (high) — [https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS](https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS)
+  - *De brontekst bevat geen inhoud over RFC 5746 of secure renegotiation vereisten.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/tls](https://www.forumstandaardisatie.nl/open-standaarden/tls)
+  - *RFC 5746 of secure renegotiation worden niet genoemd in de brontekst.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc5746.txt](https://www.rfc-editor.org/rfc/rfc5746.txt)
+  - *De bron is RFC 5746 zelf (de technische specificatie), niet de NCSC TLS Security Guidelines 2025-05. RFC 5746 definieert secure renegotiation maar zegt niets over of de NCSC het verplicht stelt in haar richtlijnen. De claim gaat over een beleids-/richtlijndocument van NCSC, niet over de RFC.*
+</details>
 
-> HSTS preloading vereist een geldig TLS-certificaat en redirect van HTTP naar HTTPS op hetzelfde domein.
+### `inet-web-0039` — reference.md:170 *(§ Preload-lijst)*
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** HSTS preload-lijst / hstspreload.org
+> Voor opname in de HSTS preload-lijst zijn een geldig TLS-certificaat en redirect van HTTP naar HTTPS op hetzelfde domein vereist.
 
-- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
-  - *De bron vermeldt niets over HSTS preloading of bijbehorende vereisten.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *RFC 6797 beschrijft geen preload-vereisten. Geldig TLS-certificaat en HTTP-naar-HTTPS redirect als preload-voorwaarden staan niet in deze spec.*
-
-### `inet-web-0048` — reference.md:231 *(§ Verplichte velden)*
-
-> Het `Expires` veld in security.txt moet een datum in ISO 8601 formaat bevatten en mag maximaal 1 jaar vooruit liggen.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** security.txt / RFC 9116
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** HSTS preload-lijst
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
-  - *De bron vermeldt niets over het Expires-veld in security.txt of ISO 8601 formaat.*
+  - *HSTS preload-lijst vereisten worden niet vermeld in de bron.*
 - **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *RFC 6797 gaat over HSTS en behandelt security.txt niet.*
+  - *RFC 6797 beschrijft de HSTS preload-lijst alleen als concept (Section 12.3) maar stelt geen formele vereisten voor opname, zoals geldig TLS-certificaat of HTTP-naar-HTTPS-redirect op hetzelfde domein.*
 
-### `inet-web-0052` — SKILL.md:239 *(§ 6. security.txt)*
+### `inet-web-0040` — reference.md:184 *(§ Preload-lijst)*
 
-> security.txt staat op de pas-toe-of-leg-uit-lijst en de overheid moet een Coordinated Vulnerability Disclosure (CVD) beleid hebben.
+> Het `preload` directive voor HSTS is onomkeerbaar op korte termijn; alle subdomeinen moeten HTTPS ondersteunen voordat dit wordt ingeschakeld.
 
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** security.txt / Forum Standaardisatie / CVD
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** HSTS preload-lijst
 
 - **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
-  - *De bron vermeldt niets over Forum Standaardisatie, CVD-beleid of verplichtingen voor de overheid.*
+  - *De onomkeerbaarheid van HSTS preload en de subdomein-eis worden niet vermeld in de bron.*
 - **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *RFC 6797 behandelt security.txt, de pas-toe-of-leg-uit-lijst noch CVD-beleid niet.*
+  - *Het 'preload' directive wordt in RFC 6797 niet gedefinieerd. De onomkeerbaarheid van preloading en subdomain-HTTPS-vereiste komen niet voor in deze bron.*
 
-### `inet-web-0053` — SKILL.md:306 *(§ Veelvoorkomende problemen)*
-
-> Het `Expires` veld in security.txt mag maximaal 1 jaar vooruit liggen; een verlopen bestand is een bekend probleem.
-
-**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** security.txt / RFC 9116
-
-- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
-  - *De bron vermeldt niets over het Expires-veld of verlopen security.txt bestanden.*
-- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
-  - *RFC 6797 behandelt security.txt en het Expires-veld niet.*
-
-## GROUNDED — minstens één bron ondersteunt de claim (2)
+## GROUNDED — minstens één bron ondersteunt de claim (1)
 
 <details>
 <summary>Klap uit voor alle GROUNDED claims</summary>
 
 ### `inet-web-0020` — SKILL.md:236 *(§ 6. security.txt)*
 
-> security.txt is gestandaardiseerd als RFC 9116 en moet bereikbaar zijn op `/.well-known/security.txt`.
+> security.txt is gestandaardiseerd in RFC 9116 en moet bereikbaar zijn op `/.well-known/security.txt`.
 
 **Type:** reference_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** security.txt / RFC 9116
 
 - **SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc9116.txt](https://www.rfc-editor.org/rfc/rfc9116.txt)
   > For web-based services, organizations MUST place the "security.txt" file under the "/.well-known/" path, e.g., https://example.com/.well-known/security.txt as per [RFC8615] of a domain name or IP address.
-  - *De RFC-nummering (9116) blijkt uit de documentheader en IANA-sectie: 'URI suffix: security.txt ... Specification document(s): RFC 9116'.*
-
-### `inet-web-0047` — reference.md:229 *(§ Verplichte velden)*
-
-> RFC 9116 definieert `Contact` (minimaal 1) en `Expires` als verplichte velden in security.txt.
-
-**Type:** reference_claim  ·  **Modaliteit:** MUST  ·  **Scope:** security.txt / RFC 9116
-
-- **SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc9116.txt](https://www.rfc-editor.org/rfc/rfc9116.txt)
-  > The "Contact" field [...] MUST always be present in a "security.txt" file. [...] The "Expires" field [...] This field MUST always be present and MUST NOT appear more than once.
+  - *RFC 9116 is inderdaad de standaard voor security.txt en verplicht de /.well-known/security.txt locatie voor webdiensten.*
 
 </details>

--- a/skills/inet-web/audit.md
+++ b/skills/inet-web/audit.md
@@ -1,0 +1,613 @@
+<!-- markdownlint-disable MD052 MD034 MD013 -->
+# Audit inet-web — 2026-05-17
+
+> Automatisch gegenereerd door audit-tooling. Niet handmatig bewerken; wijzig SKILL.md / reference.md en regenereer.
+
+## Samenvatting
+
+| Status | Aantal | % |
+|--------|--------|---|
+| UNSUPPORTED_ASSERTION | 23 | 43% |
+| CONTRADICTED | 0 | 0% |
+| PARTIALLY_GROUNDED | 6 | 11% |
+| UNGROUNDED | 22 | 42% |
+| NO_SOURCE | 0 | 0% |
+| UNVERIFIABLE | 0 | 0% |
+| KNOWN_DISCREPANCY | 0 | 0% |
+| GROUNDED | 2 | 4% |
+
+*Geverifieerd met sonnet, 9 calls, $0.9819.*
+
+## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (23)
+
+### `inet-web-0002` — SKILL.md:27 *(§ Overzicht)*
+
+> Alle door internet.nl geteste standaarden staan op de pas-toe-of-leg-uit-lijst van Forum Standaardisatie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl / Forum Standaardisatie
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron maakt geen melding van Forum Standaardisatie of de pas-toe-of-leg-uit-lijst.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *RFC 6797 bevat geen informatie over Forum Standaardisatie of de pas-toe-of-leg-uit-lijst.*
+
+### `inet-web-0003` — SKILL.md:43 *(§ 1. IPv6)*
+
+> Internet.nl test op aanwezigheid van een AAAA-record voor het domein.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl IPv6-test
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron noemt IPv6 als testonderdeel maar gaat niet in op specifieke subtests zoals AAAA-records.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *RFC 6797 gaat over HSTS, niet over IPv6 of AAAA-records.*
+
+### `inet-web-0005` — SKILL.md:45 *(§ 1. IPv6)*
+
+> Internet.nl test of nameservers bereikbaar zijn via IPv6.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl IPv6-test
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron vermeldt geen test op IPv6-bereikbaarheid van nameservers.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *RFC 6797 gaat over HSTS, niet over IPv6-bereikbaarheid van nameservers.*
+
+### `inet-web-0007` — SKILL.md:69 *(§ 2. DNSSEC)*
+
+> Internet.nl test of er een DS-record aanwezig is bij de registrar.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl DNSSEC-test
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron vermeldt geen specifieke subtest op DS-records bij de registrar.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *RFC 6797 gaat over HSTS, niet over DS-records bij registrars.*
+
+### `inet-web-0008` — SKILL.md:70 *(§ 2. DNSSEC)*
+
+> Internet.nl test op geldige RRSIG-handtekeningen en correcte ketenvalidatie (trust chain) bij DNSSEC.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl DNSSEC-test
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron vermeldt geen details over RRSIG-handtekeningen of ketenvalidatie.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *RFC 6797 gaat over HSTS, niet over DNSSEC RRSIG-handtekeningen of ketenvalidatie.*
+
+### `inet-web-0010` — SKILL.md:96 *(§ 3. HTTPS / TLS)*
+
+> TLS 1.0/1.1 geeft een phase-out waarschuwing bij internet.nl; SSL 2.0/3.0 is een harde fout.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl TLS-test
+
+- **NOT_FOUND** (high) — [https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS](https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS)
+  - *De brontekst bevat geen informatie over TLS 1.0/1.1 phase-out waarschuwingen of SSL 2.0/3.0 fouten bij internet.nl.*
+
+### `inet-web-0012` — SKILL.md:95 *(§ 3. HTTPS / TLS)*
+
+> Internet.nl test op HTTPS bereikbaarheid en redirect van HTTP naar HTTPS.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl TLS-test
+
+- **NOT_FOUND** (high) — [https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS](https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS)
+  - *De brontekst bevat geen informatie over HTTPS-bereikbaarheid of HTTP-naar-HTTPS-redirects.*
+
+### `inet-web-0013` — SKILL.md:98 *(§ 3. HTTPS / TLS)*
+
+> Internet.nl test op een geldig certificaat (keten, geldigheid, hostnaam).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl TLS-test
+
+- **NOT_FOUND** (high) — [https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS](https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS)
+  - *De brontekst bevat geen informatie over certificaatvalidatie, keten, geldigheid of hostnaam.*
+
+### `inet-web-0014` — SKILL.md:99 *(§ 3. HTTPS / TLS)*
+
+> Internet.nl test OCSP stapling als niet-scorende melding.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl TLS-test
+
+- **NOT_FOUND** (high) — [https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS](https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS)
+  - *De brontekst bevat geen informatie over OCSP stapling.*
+
+### `inet-web-0016` — SKILL.md:204 *(§ 5. Security headers)*
+
+> Internet.nl test op aanwezigheid van de `Content-Security-Policy` header.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl security headers-test
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron vermeldt 'Security options' maar specificeert niet welke headers getest worden.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *RFC 6797 gaat over HSTS, niet over Content-Security-Policy headers.*
+
+### `inet-web-0017` — SKILL.md:205 *(§ 5. Security headers)*
+
+> Internet.nl test op aanwezigheid van de `X-Frame-Options` header.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl security headers-test
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron vermeldt 'Security options' maar specificeert niet welke headers getest worden.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *RFC 6797 gaat over HSTS, niet over X-Frame-Options headers.*
+
+### `inet-web-0018` — SKILL.md:206 *(§ 5. Security headers)*
+
+> Internet.nl test op aanwezigheid van de `X-Content-Type-Options` header.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl security headers-test
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron vermeldt 'Security options' maar specificeert niet welke headers getest worden.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *RFC 6797 gaat over HSTS, niet over X-Content-Type-Options headers.*
+
+### `inet-web-0019` — SKILL.md:207 *(§ 5. Security headers)*
+
+> Internet.nl test op aanwezigheid van de `Referrer-Policy` header.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl security headers-test
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron vermeldt 'Security options' maar specificeert niet welke headers getest worden.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *RFC 6797 gaat over HSTS, niet over Referrer-Policy headers.*
+
+### `inet-web-0021` — SKILL.md:243 *(§ 6. security.txt)*
+
+> Internet.nl test of security.txt bereikbaar is op `/.well-known/security.txt` en de verplichte velden `Contact` en `Expires` bevat.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl security.txt-test
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron noemt security.txt in de kennisbank-sectie maar geeft geen details over vereiste velden of locatie.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *RFC 6797 gaat over HSTS, niet over security.txt of RFC 9116.*
+
+### `inet-web-0024` — SKILL.md:276 *(§ 7. RPKI)*
+
+> Internet.nl controleert of de ROA-status `valid` is (niet `invalid` of `unknown`).
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl RPKI-test
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron vermeldt geen details over ROA-statussen (valid/invalid/unknown).*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *De brontekst betreft RFC 6797 (HSTS), niet RPKI of ROA-statussen.*
+
+### `inet-web-0033` — reference.md:28 *(§ Aanbevolen cipher suites (NCSC))*
+
+> Voor TLS 1.3 zijn alleen TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384 en TLS_CHACHA20_POLY1305_SHA256 beschikbaar en alle zijn goed.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** TLS 1.3 cipher suites
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron vermeldt niets over TLS 1.3 cipher suites.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *De brontekst betreft RFC 6797 (HSTS), niet TLS 1.3 cipher suite specificaties.*
+
+### `inet-web-0041` — reference.md:46 *(§ Renegotiation en OCSP (NCSC 2025-05))*
+
+> Extended Master Secret (RFC 7627) is een aparte test geworden voor TLS 1.2; ontbreken telt als fout. Voor TLS 1.3 is het niet van toepassing.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NCSC TLS Security Guidelines 2025-05 / Internet.nl v1.11.0
+
+<details><summary>3x NOT_FOUND (klap uit)</summary>
+
+- **NOT_FOUND** (high) — [https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS](https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS)
+  - *De brontekst bevat geen informatie over Extended Master Secret (RFC 7627) of TLS 1.2/1.3-specifieke testvereisten.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/tls](https://www.forumstandaardisatie.nl/open-standaarden/tls)
+  - *Extended Master Secret (RFC 7627) wordt nergens in de brontekst genoemd. De bron beschrijft het functioneel toepassingsgebied en de lijststatus van TLS maar gaat niet in op specifieke testitems van Internet.nl.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc7627.txt](https://www.rfc-editor.org/rfc/rfc7627.txt)
+  - *RFC 7627 definieert de Extended Master Secret extensie zelf, maar bevat geen informatie over NCSC TLS Security Guidelines 2025-05, Internet.nl v1.11.0, teststructuur, of de classificatie als aparte test waarbij ontbreken als fout telt. De claim over hoe Internet.nl de EMS-test implementeert en categoriseert valt buiten de scope van deze RFC.*
+</details>
+
+### `inet-web-0042` — reference.md:47 *(§ Renegotiation en OCSP (NCSC 2025-05))*
+
+> OCSP stapling wordt niet langer als fout gerekend wanneer het certificaat geen OCSP-endpoint bevat (AIA zonder OCSP URI); in dat geval wordt het als niet-getest gemeld.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** NCSC TLS Security Guidelines 2025-05 / Internet.nl v1.11.0
+
+- **NOT_FOUND** (high) — [https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS](https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS)
+  - *De brontekst bevat geen informatie over OCSP stapling-gedrag bij ontbrekend OCSP-endpoint of AIA-velden.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/tls](https://www.forumstandaardisatie.nl/open-standaarden/tls)
+  - *OCSP stapling, AIA, en de specifieke testlogica van Internet.nl v1.11.0 komen niet voor in de brontekst.*
+
+### `inet-web-0045` — reference.md:184 *(§ Preload-lijst)*
+
+> Het `preload` directive voor HSTS is onomkeerbaar op korte termijn.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** HSTS preload-lijst
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron vermeldt niets over de onomkeerbaarheid van het preload directive.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *Het 'preload' directive en de onomkeerbaarheid ervan worden niet behandeld in RFC 6797.*
+
+### `inet-web-0046` — reference.md:211 *(§ Content-Security-Policy (CSP))*
+
+> CSP `frame-ancestors` directive vervangt `X-Frame-Options`.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Content-Security-Policy / security headers
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron vermeldt niets over de relatie tussen CSP frame-ancestors en X-Frame-Options.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *RFC 6797 gaat over HSTS en behandelt Content-Security-Policy, frame-ancestors noch X-Frame-Options.*
+
+### `inet-web-0049` — reference.md:260 *(§ Hoe RPKI werkt)*
+
+> Een ROA (Route Origin Authorisation) is een digitaal ondertekende verklaring die een IP-prefix koppelt aan een AS-nummer.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** RPKI / BGP
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron vermeldt niets over ROA's of de koppeling van IP-prefixen aan AS-nummers.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *RFC 6797 behandelt RPKI, ROA's en BGP niet.*
+
+### `inet-web-0050` — reference.md:264 *(§ Hoe RPKI werkt)*
+
+> RPKI-validatiestatus kent drie waarden: `Valid`, `Invalid` en `NotFound`.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** RPKI / ROV
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron vermeldt niets over RPKI-validatiestatussen.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *RFC 6797 behandelt RPKI-validatiestatus niet.*
+
+### `inet-web-0051` — reference.md:271 *(§ ROA aanmaken)*
+
+> ROA's worden aangemaakt in het RIPE NCC-portaal voor Europese netwerken via https://my.ripe.net.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** RPKI / RIPE NCC
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron vermeldt niets over RIPE NCC of het aanmaken van ROA's.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *RFC 6797 behandelt ROA's, RIPE NCC noch my.ripe.net.*
+
+## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (6)
+
+### `inet-web-0001` — SKILL.md:26 *(§ Overzicht)*
+
+> Internet.nl test websites op IPv6, DNSSEC, HTTPS/TLS, HSTS, security headers, security.txt en RPKI.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl websitetest
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  > After you enter a domain name of a website, we will test if the website offers support for the modern Internet Standards below. IPv6 : reachable via modern address? DNSSEC : domain name signed? HTTPS : secure connection? Security options : security options set? RPKI : route authorisation?
+  - *De bron bevestigt IPv6, DNSSEC, HTTPS, Security options en RPKI. HSTS en security.txt worden niet expliciet als subtests genoemd in de bron (alleen 'Security options' als verzamelnaam).*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *RFC 6797 gaat uitsluitend over HSTS. Het beschrijft niet wat internet.nl test.*
+
+### `inet-web-0004` — SKILL.md:44 *(§ 1. IPv6)*
+
+> Internet.nl test of de webserver bereikbaar is via IPv6.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl IPv6-test
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  > IPv6 : reachable via modern address?
+  - *De bron bevestigt dat bereikbaarheid via IPv6 getest wordt, maar specificeert niet dat het om de webserver gaat.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *RFC 6797 gaat over HSTS, niet over IPv6-bereikbaarheid van webservers.*
+
+### `inet-web-0006` — SKILL.md:68 *(§ 2. DNSSEC)*
+
+> Internet.nl test of de DNS-zone is gesigneerd met DNSSEC.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl DNSSEC-test
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  > DNSSEC : domain name signed?
+  - *De bron bevestigt dat DNSSEC getest wordt (domein gesigneerd), maar specificeert niet expliciet dat het om de DNS-zone gaat.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *RFC 6797 gaat over HSTS, niet over DNSSEC-zone-ondertekening.*
+
+### `inet-web-0015` — SKILL.md:176 *(§ 4. HSTS)*
+
+> Internet.nl vereist de `Strict-Transport-Security` header met een `max-age` van minimaal 31536000 (1 jaar).
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** internet.nl HSTS-test
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  > The HSTS header field below stipulates that the HSTS Policy is to remain in effect for one year (there are approximately 31536000 seconds in a year), and the policy applies only to the domain of the HSTS Host issuing it: Strict-Transport-Security: max-age=31536000
+  - *RFC 6797 bevestigt dat 31536000 seconden overeenkomt met één jaar en geeft dit als voorbeeld, maar stelt geen minimumwaarde voor max-age verplicht. De eis dat internet.nl specifiek een minimum van 31536000 vereist staat niet in deze RFC — dat is een internet.nl-testbeleid, niet een RFC-vereiste.*
+- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron noemt security options als testcategorie maar geeft geen details over HSTS-vereisten of max-age waarden.*
+
+### `inet-web-0023` — SKILL.md:275 *(§ 7. RPKI)*
+
+> Internet.nl test RPKI door te controleren of er een geldig ROA-record aanwezig is voor het IP-adres van de webserver.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl RPKI-test
+
+- **PARTIALLY_SUPPORTED** (low) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  > RPKI : route authorisation?
+  - *De bron bevestigt dat RPKI getest wordt, maar vermeldt niet specifiek ROA-records of IP-adressen van de webserver.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *De brontekst betreft RFC 6797 (HSTS), niet RPKI of ROA-records. Geen relevante inhoud voor deze claim.*
+
+### `inet-web-0040` — reference.md:45 *(§ Renegotiation en OCSP (NCSC 2025-05))*
+
+> Secure renegotiation (RFC 5746) blijft verplicht.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** NCSC TLS Security Guidelines 2025-05 / Internet.nl v1.11.0
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://www.rfc-editor.org/rfc/rfc5746.txt](https://www.rfc-editor.org/rfc/rfc5746.txt)
+  > Servers SHOULD NOT allow clients to renegotiate without using this extension. Many servers can mitigate this attack simply by refusing to renegotiate at all.
+  - *RFC 5746 definieert het secure renegotiation mechanisme en stelt dat servers het MOETEN implementeren voor de initiële handshake ('even servers that do not support renegotiation MUST implement the minimal version of the extension described in this document for initial handshakes'). De RFC ondersteunt de technische basis van de claim, maar de claim verwijst specifiek naar NCSC TLS Security Guidelines 2025-05 / Internet.nl v1.11.0 als normatieve context. De RFC zelf spreekt van SHOULD NOT (servers mogen renegotiatie toestaan mits via de extensie), niet van een absolute verplichting. De verplichtstelling als zodanig ('verplicht') is een beleidsinterpretatie die de RFC deels maar niet volledig dekt.*
+- **NOT_FOUND** (high) — [https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS](https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS)
+  - *De brontekst bevat geen informatie over secure renegotiation (RFC 5746).*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/tls](https://www.forumstandaardisatie.nl/open-standaarden/tls)
+  - *De brontekst verwijst naar NCSC TLS-richtlijnen en Internet.nl als hulpmiddelen, maar bevat geen inhoudelijke specificaties over secure renegotiation (RFC 5746) of verplichtingen daaromtrent.*
+
+## UNGROUNDED — geen bron ondersteunt de claim (22)
+
+### `inet-web-0009` — SKILL.md:89 *(§ 3. HTTPS / TLS)*
+
+> Internet.nl vereist TLS 1.2 of 1.3 met sterke cipher suites.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** internet.nl TLS-test
+
+- **NOT_FOUND** (high) — [https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS](https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS)
+  - *De brontekst bevat alleen een pagina-layout met downloadlinks voor TLS-richtlijnen. Er staat geen inhoudelijke informatie over internet.nl-testvereisten of specifieke TLS-versies.*
+
+### `inet-web-0011` — SKILL.md:97 *(§ 3. HTTPS / TLS)*
+
+> Internet.nl test op sterke cipher suites; RC4, 3DES, NULL en export ciphers zijn niet toegestaan.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** internet.nl TLS-test / cipher suites
+
+- **NOT_FOUND** (high) — [https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS](https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS)
+  - *De brontekst bevat geen informatie over cipher suite vereisten of verboden ciphers.*
+
+### `inet-web-0022` — SKILL.md:245 *(§ 6. security.txt)*
+
+> Digitale ondertekening (PGP) van security.txt is aanbevolen.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** security.txt / RFC 9116
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron vermeldt niets over PGP-ondertekening van security.txt.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *RFC 6797 gaat over HSTS, niet over PGP-ondertekening van security.txt.*
+
+### `inet-web-0025` — reference.md:13 *(§ Aanbevolen cipher suites (NCSC))*
+
+> NCSC adviseert TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 als aanbevolen (voorkeur) cipher suite voor TLS 1.2.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** NCSC TLS Security Guidelines / TLS 1.2 cipher suites
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron vermeldt niets over NCSC TLS-richtlijnen of specifieke cipher suites.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *De brontekst betreft RFC 6797 (HSTS), niet NCSC TLS-richtlijnen of cipher suites.*
+
+### `inet-web-0026` — reference.md:14 *(§ Aanbevolen cipher suites (NCSC))*
+
+> NCSC adviseert TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 als aanbevolen (voorkeur) cipher suite voor TLS 1.2.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** NCSC TLS Security Guidelines / TLS 1.2 cipher suites
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron vermeldt niets over NCSC TLS-richtlijnen of specifieke cipher suites.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *De brontekst betreft RFC 6797 (HSTS), niet NCSC TLS-richtlijnen of cipher suites.*
+
+### `inet-web-0027` — reference.md:15 *(§ Aanbevolen cipher suites (NCSC))*
+
+> NCSC adviseert TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 als aanbevolen (voorkeur) cipher suite voor TLS 1.2.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** NCSC TLS Security Guidelines / TLS 1.2 cipher suites
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron vermeldt niets over NCSC TLS-richtlijnen of specifieke cipher suites.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *De brontekst betreft RFC 6797 (HSTS), niet NCSC TLS-richtlijnen of cipher suites.*
+
+### `inet-web-0028` — reference.md:16 *(§ Aanbevolen cipher suites (NCSC))*
+
+> NCSC adviseert TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 als aanbevolen (voorkeur) cipher suite voor TLS 1.2.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** NCSC TLS Security Guidelines / TLS 1.2 cipher suites
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron vermeldt niets over NCSC TLS-richtlijnen of specifieke cipher suites.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *De brontekst betreft RFC 6797 (HSTS), niet NCSC TLS-richtlijnen of cipher suites.*
+
+### `inet-web-0029` — reference.md:17 *(§ Aanbevolen cipher suites (NCSC))*
+
+> NCSC adviseert TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 als aanbevolen (voorkeur) cipher suite voor TLS 1.2.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** NCSC TLS Security Guidelines / TLS 1.2 cipher suites
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron vermeldt niets over NCSC TLS-richtlijnen of specifieke cipher suites.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *De brontekst betreft RFC 6797 (HSTS), niet NCSC TLS-richtlijnen of cipher suites.*
+
+### `inet-web-0030` — reference.md:18 *(§ Aanbevolen cipher suites (NCSC))*
+
+> NCSC adviseert TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 als aanbevolen (voorkeur) cipher suite voor TLS 1.2.
+
+**Type:** normative_requirement  ·  **Modaliteit:** SHOULD  ·  **Scope:** NCSC TLS Security Guidelines / TLS 1.2 cipher suites
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron vermeldt niets over NCSC TLS-richtlijnen of specifieke cipher suites.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *De brontekst betreft RFC 6797 (HSTS), niet NCSC TLS-richtlijnen of cipher suites.*
+
+### `inet-web-0031` — reference.md:25 *(§ Aanbevolen cipher suites (NCSC))*
+
+> Cipher suites met RC4, 3DES, NULL, EXPORT, DES of MD5 zijn niet toegestaan volgens NCSC.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** NCSC TLS Security Guidelines / cipher suites
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron vermeldt niets over verboden cipher suites of NCSC-richtlijnen.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *De brontekst betreft RFC 6797 (HSTS), niet NCSC-richtlijnen over verboden cipher suites.*
+
+### `inet-web-0032` — reference.md:26 *(§ Aanbevolen cipher suites (NCSC))*
+
+> TLS_RSA_* cipher suites zijn niet toegestaan vanwege ontbreken van forward secrecy.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** NCSC TLS Security Guidelines / cipher suites
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron vermeldt niets over TLS_RSA_* cipher suites of forward secrecy.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *De brontekst betreft RFC 6797 (HSTS), niet forward secrecy-vereisten of TLS_RSA_* cipher suites.*
+
+### `inet-web-0034` — reference.md:35 *(§ Certificaatvereisten)*
+
+> TLS-certificaten vereisen minimaal 2048-bit RSA of 256-bit ECDSA sleutellengte.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** TLS certificaatvereisten
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron vermeldt niets over sleutellengtes voor TLS-certificaten.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *De brontekst betreft RFC 6797 (HSTS), niet sleutellengtes voor TLS-certificaten.*
+
+### `inet-web-0035` — reference.md:36 *(§ Certificaatvereisten)*
+
+> TLS-certificaten vereisen SHA-256 of hoger als hash-algoritme.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** TLS certificaatvereisten
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron vermeldt niets over hash-algoritmen voor TLS-certificaten.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *De brontekst betreft RFC 6797 (HSTS), niet hash-algoritme-vereisten voor TLS-certificaten.*
+
+### `inet-web-0036` — reference.md:37 *(§ Certificaatvereisten)*
+
+> TLS-certificaten vereisen een geldige keten naar een vertrouwde root CA.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** TLS certificaatvereisten
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron vermeldt niets over certificaatketens of vertrouwde root CA's.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *De brontekst betreft RFC 6797 (HSTS). Hoewel HSTS vertrouwde certificaatketens veronderstelt, specificeert de RFC geen expliciete eis voor een geldige keten naar een vertrouwde root CA als certificaatvereiste.*
+
+### `inet-web-0037` — reference.md:38 *(§ Certificaatvereisten)*
+
+> De hostnaam moet aanwezig zijn in het Subject Alternative Name (SAN) veld van het TLS-certificaat.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** TLS certificaatvereisten
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron vermeldt niets over Subject Alternative Name velden in certificaten.*
+- **OUT_OF_SCOPE** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *De brontekst betreft RFC 6797 (HSTS), niet Subject Alternative Name (SAN)-vereisten voor TLS-certificaten.*
+
+### `inet-web-0038` — reference.md:44 *(§ Renegotiation en OCSP (NCSC 2025-05))*
+
+> Met de NCSC TLS-richtlijnen van mei 2025 (geïmplementeerd in Internet.nl v1.11.0) is client-initiated renegotiation acceptabel mits het aantal beperkt blijft tot minder dan 10 per verbinding.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MAY  ·  **Scope:** NCSC TLS Security Guidelines 2025-05 / Internet.nl v1.11.0
+
+- **NOT_FOUND** (high) — [https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS](https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS)
+  - *De brontekst is een webpagina met uitsluitend downloadlinks naar PDF-documenten. De inhoud van de TLS-richtlijnen 2025-05 zelf is niet aangeleverd; claims over renegotiation-limieten kunnen hier niet worden geverifieerd.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/tls](https://www.forumstandaardisatie.nl/open-standaarden/tls)
+  - *De brontekst behandelt TLS algemeen (versies 1.2 en 1.3, toepassingsgebied, adoptieadviezen) maar bevat geen informatie over client-initiated renegotiation, NCSC TLS-richtlijnen van mei 2025, of Internet.nl v1.11.0.*
+
+### `inet-web-0039` — reference.md:44 *(§ Renegotiation en OCSP (NCSC 2025-05))*
+
+> Onbeperkte client renegotiation blijft een fout vanwege DoS-risico.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST_NOT  ·  **Scope:** NCSC TLS Security Guidelines 2025-05 / Internet.nl v1.11.0
+
+- **NOT_FOUND** (high) — [https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS](https://www.ncsc.nl/en/transport-layer-security/ICT-beveiligingsrichtlijnen-voor-TLS)
+  - *De brontekst bevat geen inhoudelijke richtlijnen over client renegotiation of DoS-risico's.*
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden/tls](https://www.forumstandaardisatie.nl/open-standaarden/tls)
+  - *De brontekst bevat geen informatie over client renegotiation, DoS-risico's in die context, of de specifieke NCSC/Internet.nl versie-scope van de claim.*
+
+### `inet-web-0043` — reference.md:173 *(§ Preload-lijst)*
+
+> HSTS preloading vereist een `max-age` van minimaal 31536000, de `includeSubDomains` directive én de `preload` directive.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** HSTS preload-lijst / hstspreload.org
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron vermeldt niets over HSTS preloading of bijbehorende vereisten.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *RFC 6797 definieert HSTS maar beschrijft geen preload-vereisten. Het 'preload' directive wordt niet vermeld in deze spec. De minimale max-age van 31536000 voor preloading is een vereiste van hstspreload.org, niet van RFC 6797. De spec noemt wel max-age=31536000 als voorbeeld van een jaar, maar niet als preload-vereiste.*
+
+### `inet-web-0044` — reference.md:171 *(§ Preload-lijst)*
+
+> HSTS preloading vereist een geldig TLS-certificaat en redirect van HTTP naar HTTPS op hetzelfde domein.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** HSTS preload-lijst / hstspreload.org
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron vermeldt niets over HSTS preloading of bijbehorende vereisten.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *RFC 6797 beschrijft geen preload-vereisten. Geldig TLS-certificaat en HTTP-naar-HTTPS redirect als preload-voorwaarden staan niet in deze spec.*
+
+### `inet-web-0048` — reference.md:231 *(§ Verplichte velden)*
+
+> Het `Expires` veld in security.txt moet een datum in ISO 8601 formaat bevatten en mag maximaal 1 jaar vooruit liggen.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** security.txt / RFC 9116
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron vermeldt niets over het Expires-veld in security.txt of ISO 8601 formaat.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *RFC 6797 gaat over HSTS en behandelt security.txt niet.*
+
+### `inet-web-0052` — SKILL.md:239 *(§ 6. security.txt)*
+
+> security.txt staat op de pas-toe-of-leg-uit-lijst en de overheid moet een Coordinated Vulnerability Disclosure (CVD) beleid hebben.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** security.txt / Forum Standaardisatie / CVD
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron vermeldt niets over Forum Standaardisatie, CVD-beleid of verplichtingen voor de overheid.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *RFC 6797 behandelt security.txt, de pas-toe-of-leg-uit-lijst noch CVD-beleid niet.*
+
+### `inet-web-0053` — SKILL.md:306 *(§ Veelvoorkomende problemen)*
+
+> Het `Expires` veld in security.txt mag maximaal 1 jaar vooruit liggen; een verlopen bestand is een bekend probleem.
+
+**Type:** normative_requirement  ·  **Modaliteit:** MUST  ·  **Scope:** security.txt / RFC 9116
+
+- **NOT_FOUND** (high) — [https://internet.nl/test-site/](https://internet.nl/test-site/)
+  - *De bron vermeldt niets over het Expires-veld of verlopen security.txt bestanden.*
+- **NOT_FOUND** (high) — [https://www.rfc-editor.org/rfc/rfc6797.txt](https://www.rfc-editor.org/rfc/rfc6797.txt)
+  - *RFC 6797 behandelt security.txt en het Expires-veld niet.*
+
+## GROUNDED — minstens één bron ondersteunt de claim (2)
+
+<details>
+<summary>Klap uit voor alle GROUNDED claims</summary>
+
+### `inet-web-0020` — SKILL.md:236 *(§ 6. security.txt)*
+
+> security.txt is gestandaardiseerd als RFC 9116 en moet bereikbaar zijn op `/.well-known/security.txt`.
+
+**Type:** reference_claim  ·  **Modaliteit:** STATEMENT  ·  **Scope:** security.txt / RFC 9116
+
+- **SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc9116.txt](https://www.rfc-editor.org/rfc/rfc9116.txt)
+  > For web-based services, organizations MUST place the "security.txt" file under the "/.well-known/" path, e.g., https://example.com/.well-known/security.txt as per [RFC8615] of a domain name or IP address.
+  - *De RFC-nummering (9116) blijkt uit de documentheader en IANA-sectie: 'URI suffix: security.txt ... Specification document(s): RFC 9116'.*
+
+### `inet-web-0047` — reference.md:229 *(§ Verplichte velden)*
+
+> RFC 9116 definieert `Contact` (minimaal 1) en `Expires` als verplichte velden in security.txt.
+
+**Type:** reference_claim  ·  **Modaliteit:** MUST  ·  **Scope:** security.txt / RFC 9116
+
+- **SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc9116.txt](https://www.rfc-editor.org/rfc/rfc9116.txt)
+  > The "Contact" field [...] MUST always be present in a "security.txt" file. [...] The "Expires" field [...] This field MUST always be present and MUST NOT appear more than once.
+
+</details>

--- a/skills/inet/audit.md
+++ b/skills/inet/audit.md
@@ -1,0 +1,260 @@
+<!-- markdownlint-disable MD052 MD034 MD013 -->
+# Audit inet — 2026-05-17
+
+> Automatisch gegenereerd door audit-tooling. Niet handmatig bewerken; wijzig SKILL.md / reference.md en regenereer.
+
+## Samenvatting
+
+| Status | Aantal | % |
+|--------|--------|---|
+| UNSUPPORTED_ASSERTION | 14 | 70% |
+| CONTRADICTED | 0 | 0% |
+| PARTIALLY_GROUNDED | 1 | 5% |
+| UNGROUNDED | 0 | 0% |
+| NO_SOURCE | 0 | 0% |
+| UNVERIFIABLE | 0 | 0% |
+| KNOWN_DISCREPANCY | 0 | 0% |
+| GROUNDED | 5 | 25% |
+
+*Geverifieerd met sonnet, 6 calls, $0.3397.*
+
+## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (14)
+
+### `inet-0001` — SKILL.md:24 *(§ Wat is internet.nl?)*
+
+> Internet.nl is een initiatief van de Nederlandse overheid waarmee organisaties kunnen testen of hun website en e-mail voldoen aan moderne internetstandaarden.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl platform
+
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
+  - *De brontekst beschrijft de website van Forum Standaardisatie over open standaarden. Internet.nl wordt nergens vermeld.*
+
+### `inet-0002` — SKILL.md:26 *(§ Wat is internet.nl?)*
+
+> De standaarden getest door internet.nl staan op de pas-toe-of-leg-uit-lijst van Forum Standaardisatie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl / Forum Standaardisatie
+
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
+  - *Internet.nl wordt niet vermeld in de brontekst. De bron bevestigt wel dat er een 'pas-toe-of-leg-uit'-lijst bestaat, maar legt geen koppeling met internet.nl.*
+
+### `inet-0003` — SKILL.md:52 *(§ Webstandaarden)*
+
+> IPv6 heeft de Forum Standaardisatie-status 'Verplicht (pas-toe-of-leg-uit)' voor webstandaarden.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IPv6 / Forum Standaardisatie webstandaarden
+
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
+  - *IPv6 wordt niet specifiek genoemd in de brontekst. De bron is een navigatiepagina zonder inhoudelijke details over individuele standaarden.*
+- **NOT_FOUND** (high) — [https://internet.nl/about/](https://internet.nl/about/)
+  - *De brontekst beschrijft wat internet.nl is en wie eraan meewerkt, maar bevat geen informatie over Forum Standaardisatie-statussen of specifieke standaarden zoals IPv6.*
+
+### `inet-0004` — SKILL.md:53 *(§ Webstandaarden)*
+
+> DNSSEC heeft de Forum Standaardisatie-status 'Verplicht (pas-toe-of-leg-uit)' en beveiligt DNS-naamresolutie tegen manipulatie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DNSSEC / Forum Standaardisatie webstandaarden
+
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
+  - *DNSSEC wordt niet vermeld in de brontekst.*
+- **NOT_FOUND** (high) — [https://internet.nl/about/](https://internet.nl/about/)
+  - *De brontekst noemt DNSSEC niet en bevat geen Forum Standaardisatie-statusinformatie.*
+
+### `inet-0005` — SKILL.md:54 *(§ Webstandaarden)*
+
+> HTTPS (TLS 1.2/1.3) heeft de Forum Standaardisatie-status 'Verplicht (pas-toe-of-leg-uit)'.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** HTTPS/TLS / Forum Standaardisatie webstandaarden
+
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
+  - *HTTPS/TLS wordt niet vermeld in de brontekst.*
+- **NOT_FOUND** (high) — [https://internet.nl/about/](https://internet.nl/about/)
+  - *HTTPS/TLS wordt niet vermeld in de brontekst. Geen Forum Standaardisatie-informatie aanwezig.*
+
+### `inet-0006` — SKILL.md:55 *(§ Webstandaarden)*
+
+> HSTS heeft de Forum Standaardisatie-status 'Verplicht (pas-toe-of-leg-uit)' en dwingt browsers HTTPS te gebruiken.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** HSTS / Forum Standaardisatie webstandaarden
+
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
+  - *HSTS wordt niet vermeld in de brontekst.*
+- **NOT_FOUND** (high) — [https://internet.nl/about/](https://internet.nl/about/)
+  - *HSTS wordt niet vermeld in de brontekst.*
+
+### `inet-0007` — SKILL.md:56 *(§ Webstandaarden)*
+
+> Security headers (CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy) worden getest door internet.nl maar hebben geen Forum Standaardisatie-status.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Security headers / internet.nl webstandaarden
+
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
+  - *Security headers (CSP, X-Frame-Options, etc.) worden niet vermeld in de brontekst.*
+- **NOT_FOUND** (high) — [https://internet.nl/about/](https://internet.nl/about/)
+  - *Security headers (CSP, X-Frame-Options, etc.) worden niet vermeld in de brontekst.*
+
+### `inet-0009` — SKILL.md:58 *(§ Webstandaarden)*
+
+> RPKI (Route Origin Validation) heeft de Forum Standaardisatie-status 'Verplicht (pas-toe-of-leg-uit)' en beschermt BGP-routing.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** RPKI / Forum Standaardisatie webstandaarden
+
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
+  - *RPKI wordt niet vermeld in de brontekst.*
+- **NOT_FOUND** (high) — [https://internet.nl/about/](https://internet.nl/about/)
+  - *RPKI wordt niet vermeld in de brontekst.*
+
+### `inet-0010` — SKILL.md:64 *(§ Mailstandaarden)*
+
+> SPF heeft de Forum Standaardisatie-status 'Verplicht (pas-toe-of-leg-uit)' en autoriseert verzendende mailservers.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** SPF / Forum Standaardisatie mailstandaarden
+
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
+  - *SPF wordt niet vermeld in de brontekst.*
+- **NOT_FOUND** (high) — [https://internet.nl/about/](https://internet.nl/about/)
+  - *SPF wordt niet vermeld in de brontekst. De bron noemt SMTP alleen als voorbeeld van een bekende e-mailprotocol, zonder Forum Standaardisatie-statusinformatie.*
+
+### `inet-0011` — SKILL.md:65 *(§ Mailstandaarden)*
+
+> DKIM heeft de Forum Standaardisatie-status 'Verplicht (pas-toe-of-leg-uit)' en plaatst een digitale handtekening op e-mail.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DKIM / Forum Standaardisatie mailstandaarden
+
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
+  - *DKIM wordt niet vermeld in de brontekst.*
+- **NOT_FOUND** (high) — [https://internet.nl/about/](https://internet.nl/about/)
+  - *DKIM wordt niet vermeld in de brontekst.*
+
+### `inet-0012` — SKILL.md:66 *(§ Mailstandaarden)*
+
+> DMARC heeft de Forum Standaardisatie-status 'Verplicht (pas-toe-of-leg-uit)' en bouwt voort op SPF en DKIM.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DMARC / Forum Standaardisatie mailstandaarden
+
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
+  - *DMARC wordt niet vermeld in de brontekst.*
+- **NOT_FOUND** (high) — [https://internet.nl/about/](https://internet.nl/about/)
+  - *DMARC wordt niet vermeld in de brontekst.*
+
+### `inet-0013` — SKILL.md:67 *(§ Mailstandaarden)*
+
+> STARTTLS + DANE heeft de Forum Standaardisatie-status 'Verplicht (pas-toe-of-leg-uit)'; STARTTLS versleutelt SMTP-verkeer en DANE biedt DNS-gebaseerde certificaatverificatie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** STARTTLS + DANE / Forum Standaardisatie mailstandaarden
+
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
+  - *STARTTLS en DANE worden niet vermeld in de brontekst.*
+- **NOT_FOUND** (high) — [https://internet.nl/about/](https://internet.nl/about/)
+  - *STARTTLS en DANE worden niet vermeld in de brontekst.*
+
+### `inet-0014` — SKILL.md:68 *(§ Mailstandaarden)*
+
+> IPv6 heeft de Forum Standaardisatie-status 'Verplicht (pas-toe-of-leg-uit)' voor de bereikbaarheid van MX- en nameservers.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IPv6 / Forum Standaardisatie mailstandaarden
+
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
+  - *IPv6 voor MX- en nameservers wordt niet vermeld in de brontekst.*
+- **NOT_FOUND** (high) — [https://internet.nl/about/](https://internet.nl/about/)
+  - *IPv6 voor MX- en nameservers wordt niet vermeld in de brontekst.*
+
+### `inet-0015` — SKILL.md:69 *(§ Mailstandaarden)*
+
+> RPKI heeft de Forum Standaardisatie-status 'Verplicht (pas-toe-of-leg-uit)' voor MX- en nameservers.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** RPKI / Forum Standaardisatie mailstandaarden
+
+- **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
+  - *RPKI voor MX- en nameservers wordt niet vermeld in de brontekst.*
+- **NOT_FOUND** (high) — [https://internet.nl/about/](https://internet.nl/about/)
+  - *RPKI voor MX- en nameservers wordt niet vermeld in de brontekst.*
+
+## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (1)
+
+### `inet-0008` — SKILL.md:57 *(§ Webstandaarden)*
+
+> security.txt heeft de Forum Standaardisatie-status 'Verplicht (pas-toe-of-leg-uit)' en is gedefinieerd in RFC 9116.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** security.txt / Forum Standaardisatie webstandaarden
+
+- **PARTIALLY_SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc9116.txt](https://www.rfc-editor.org/rfc/rfc9116.txt)
+  > This document defines a machine-parsable format ("security.txt") to help organizations describe their vulnerability disclosure practices... RFC 9116
+  - *De bron bevestigt dat security.txt gedefinieerd is in RFC 9116. De claim over de Forum Standaardisatie-status 'Verplicht (pas-toe-of-leg-uit)' wordt niet vermeld in deze bron — dat is een Nederlandse overheids-classificatie die buiten de scope van de RFC valt.*
+
+## GROUNDED — minstens één bron ondersteunt de claim (5)
+
+<details>
+<summary>Klap uit voor alle GROUNDED claims</summary>
+
+### `inet-0016` — SKILL.md:78 *(§ Repositories)*
+
+> De internet.nl testsuite (Internet.nl repository) is gepubliceerd onder Apache-2.0 licentie voor code en CC-BY-4.0 voor vertalingen.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl repository licenties
+
+- **SUPPORTED** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+  > This project is licensed under the Apache License, Version 2.0 - see the LICENSE-Apache-2.0.txt file for details. The files under the /translations folder are licensed under Attribution 4.0 International (CC BY 4.0) - see the LICENSE-CC-BY-4.0.txt file for details.
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl-API-docs](https://github.com/internetstandards/Internet.nl-API-docs)
+  - *De brontekst is de GitHub-pagina van de Internet.nl-API-docs repository en bevat geen informatie over de licentie van de internet.nl testsuite (het hoofdrepository). Er wordt alleen een LICENSE-CC-BY-4.0.txt bestand genoemd voor deze docs-repo zelf.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *De bron vermeldt alleen CC-BY-4.0 (zichtbaar in het bestandsoverzicht: LICENSE-CC-BY-4.0.txt), maar gaat over de toolbox-wiki, niet over de internet.nl testsuite. Apache-2.0 en vertalingen worden niet genoemd.*
+
+### `inet-0017` — SKILL.md:79 *(§ Repositories)*
+
+> De Internet.nl-API-docs repository (documentatie voor de batch API v2) is gepubliceerd onder de CC-BY-4.0 licentie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl Batch API v2 documentatie
+
+- **SUPPORTED** (medium) — [https://github.com/internetstandards/Internet.nl-API-docs](https://github.com/internetstandards/Internet.nl-API-docs)
+  > LICENSE-CC-BY-4.0.txt
+  - *De brontekst toont een bestand genaamd 'LICENSE-CC-BY-4.0.txt' in de Internet.nl-API-docs repository. Dit is een sterke indicatie dat de CC-BY-4.0 licentie van toepassing is, hoewel de volledige licentietekst niet in de verstrekte bron staat.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+  - *De bron beschrijft alleen de Internet.nl repository zelf, niet een aparte API-docs repository. Geen informatie over de licentie van die repository.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *De bron behandelt de toolbox-wiki repository, niet de Internet.nl-API-docs repository. De CC-BY-4.0 licentie voor die specifieke repo wordt hier niet bevestigd.*
+
+### `inet-0018` — SKILL.md:80 *(§ Repositories)*
+
+> De toolbox-wiki repository (implementatiegidsen per standaard en platform) is gepubliceerd onder de CC-BY-4.0 licentie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl toolbox-wiki licentie
+
+- **SUPPORTED** (medium) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  > LICENSE-CC-BY-4.0.txt (bestandsnaam zichtbaar in repository bestandsoverzicht van internetstandards/toolbox-wiki)
+  - *De aanwezigheid van LICENSE-CC-BY-4.0.txt in de repository impliceert sterk de CC-BY-4.0 licentie, maar de licentie wordt nergens expliciet als tekst vermeld in de aangeleverde brontekst. Confidence medium omdat het een bestandsnaam is, geen uitgeschreven licentievermelding.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+  - *De bron beschrijft alleen de Internet.nl repository zelf, niet een aparte toolbox-wiki repository. Geen informatie over de licentie van die repository.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl-API-docs](https://github.com/internetstandards/Internet.nl-API-docs)
+  - *De brontekst behandelt uitsluitend de Internet.nl-API-docs repository. Er is geen informatie over een toolbox-wiki repository of de licentie daarvan.*
+
+### `inet-0019` — SKILL.md:78 *(§ Repositories)*
+
+> De internet.nl testsuite is gebouwd met Python/Django.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl technische implementatie
+
+- **SUPPORTED** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+  > Python 3 (main programming language) Django (web framework)
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl-API-docs](https://github.com/internetstandards/Internet.nl-API-docs)
+  - *De brontekst bevat geen informatie over de technische implementatie (Python/Django) van de internet.nl testsuite.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *De bron gaat over de toolbox-wiki (implementatiegidsen voor mailstandaarden), niet over de technische implementatie van de testsuite. Python/Django wordt niet vermeld.*
+
+### `inet-0020` — SKILL.md:73 *(§ Repositories)*
+
+> De broncode en documentatie van internet.nl staan onder de GitHub-organisatie 'internetstandards'.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl GitHub organisatie
+
+- **SUPPORTED** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+  > internetstandards / Internet.nl Public
+  - *De repository URL en header tonen duidelijk dat de code staat onder de GitHub-organisatie 'internetstandards'.*
+- **SUPPORTED** (high) — [https://github.com/internetstandards/Internet.nl-API-docs](https://github.com/internetstandards/Internet.nl-API-docs)
+  > internetstandards / Internet.nl-API-docs Public
+  - *De brontekst toont duidelijk dat de repository onder de GitHub-organisatie 'internetstandards' staat: 'internetstandards / Internet.nl-API-docs'.*
+- **SUPPORTED** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  > internetstandards / toolbox-wiki Public
+  - *De repository staat expliciet onder de GitHub-organisatie 'internetstandards', zoals zichtbaar in de repository-naam en navigatie.*
+
+</details>

--- a/skills/inet/audit.md
+++ b/skills/inet/audit.md
@@ -7,16 +7,16 @@
 
 | Status | Aantal | % |
 |--------|--------|---|
-| UNSUPPORTED_ASSERTION | 14 | 70% |
+| UNSUPPORTED_ASSERTION | 14 | 74% |
 | CONTRADICTED | 0 | 0% |
-| PARTIALLY_GROUNDED | 1 | 5% |
+| PARTIALLY_GROUNDED | 3 | 16% |
 | UNGROUNDED | 0 | 0% |
 | NO_SOURCE | 0 | 0% |
 | UNVERIFIABLE | 0 | 0% |
 | KNOWN_DISCREPANCY | 0 | 0% |
-| GROUNDED | 5 | 25% |
+| GROUNDED | 2 | 11% |
 
-*Geverifieerd met sonnet, 6 calls, $0.3397.*
+*Geverifieerd met sonnet, 6 calls, $0.3387.*
 
 ## UNSUPPORTED_ASSERTION — stellige bewering zonder enige bronsteun (mogelijke hallucinatie) (14)
 
@@ -24,237 +24,236 @@
 
 > Internet.nl is een initiatief van de Nederlandse overheid waarmee organisaties kunnen testen of hun website en e-mail voldoen aan moderne internetstandaarden.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl platform
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl algemeen
 
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
-  - *De brontekst beschrijft de website van Forum Standaardisatie over open standaarden. Internet.nl wordt nergens vermeld.*
+  - *De brontekst is de algemene lijstpagina van Forum Standaardisatie en bevat geen informatie over internet.nl of wat het initiatief doet.*
 
 ### `inet-0002` — SKILL.md:26 *(§ Wat is internet.nl?)*
 
-> De standaarden getest door internet.nl staan op de pas-toe-of-leg-uit-lijst van Forum Standaardisatie.
+> De internetstandaarden getest door internet.nl staan op de pas-toe-of-leg-uit-lijst van Forum Standaardisatie.
 
 **Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl / Forum Standaardisatie
 
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
-  - *Internet.nl wordt niet vermeld in de brontekst. De bron bevestigt wel dat er een 'pas-toe-of-leg-uit'-lijst bestaat, maar legt geen koppeling met internet.nl.*
+  - *De bron vermeldt het bestaan van de pas-toe-of-leg-uit-lijst maar noemt internet.nl niet en koppelt de geteste standaarden niet aan internet.nl.*
 
 ### `inet-0003` — SKILL.md:52 *(§ Webstandaarden)*
 
 > IPv6 heeft de Forum Standaardisatie-status 'Verplicht (pas-toe-of-leg-uit)' voor webstandaarden.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IPv6 / Forum Standaardisatie webstandaarden
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Webstandaarden / Forum Standaardisatie
 
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
-  - *IPv6 wordt niet specifiek genoemd in de brontekst. De bron is een navigatiepagina zonder inhoudelijke details over individuele standaarden.*
+  - *De bron noemt de pas-toe-of-leg-uit-lijst als concept maar somt geen specifieke standaarden zoals IPv6 op.*
 - **NOT_FOUND** (high) — [https://internet.nl/about/](https://internet.nl/about/)
-  - *De brontekst beschrijft wat internet.nl is en wie eraan meewerkt, maar bevat geen informatie over Forum Standaardisatie-statussen of specifieke standaarden zoals IPv6.*
+  - *De brontekst gaat over wat internet.nl is en wie erachter zit. Forum Standaardisatie-statussen worden niet vermeld.*
 
 ### `inet-0004` — SKILL.md:53 *(§ Webstandaarden)*
 
 > DNSSEC heeft de Forum Standaardisatie-status 'Verplicht (pas-toe-of-leg-uit)' en beveiligt DNS-naamresolutie tegen manipulatie.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DNSSEC / Forum Standaardisatie webstandaarden
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Webstandaarden / Forum Standaardisatie
 
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
-  - *DNSSEC wordt niet vermeld in de brontekst.*
+  - *DNSSEC wordt niet genoemd in de brontekst.*
 - **NOT_FOUND** (high) — [https://internet.nl/about/](https://internet.nl/about/)
-  - *De brontekst noemt DNSSEC niet en bevat geen Forum Standaardisatie-statusinformatie.*
+  - *De brontekst gaat over wat internet.nl is en wie erachter zit. Forum Standaardisatie-statussen worden niet vermeld.*
 
 ### `inet-0005` — SKILL.md:54 *(§ Webstandaarden)*
 
 > HTTPS (TLS 1.2/1.3) heeft de Forum Standaardisatie-status 'Verplicht (pas-toe-of-leg-uit)'.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** HTTPS/TLS / Forum Standaardisatie webstandaarden
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Webstandaarden / Forum Standaardisatie
 
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
-  - *HTTPS/TLS wordt niet vermeld in de brontekst.*
+  - *HTTPS/TLS wordt niet genoemd in de brontekst.*
 - **NOT_FOUND** (high) — [https://internet.nl/about/](https://internet.nl/about/)
-  - *HTTPS/TLS wordt niet vermeld in de brontekst. Geen Forum Standaardisatie-informatie aanwezig.*
+  - *De brontekst gaat over wat internet.nl is en wie erachter zit. Forum Standaardisatie-statussen worden niet vermeld.*
 
 ### `inet-0006` — SKILL.md:55 *(§ Webstandaarden)*
 
 > HSTS heeft de Forum Standaardisatie-status 'Verplicht (pas-toe-of-leg-uit)' en dwingt browsers HTTPS te gebruiken.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** HSTS / Forum Standaardisatie webstandaarden
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Webstandaarden / Forum Standaardisatie
 
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
-  - *HSTS wordt niet vermeld in de brontekst.*
+  - *HSTS wordt niet genoemd in de brontekst.*
 - **NOT_FOUND** (high) — [https://internet.nl/about/](https://internet.nl/about/)
-  - *HSTS wordt niet vermeld in de brontekst.*
+  - *De brontekst gaat over wat internet.nl is en wie erachter zit. Forum Standaardisatie-statussen worden niet vermeld.*
 
 ### `inet-0007` — SKILL.md:56 *(§ Webstandaarden)*
 
 > Security headers (CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy) worden getest door internet.nl maar hebben geen Forum Standaardisatie-status.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Security headers / internet.nl webstandaarden
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Webstandaarden / Forum Standaardisatie
 
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
-  - *Security headers (CSP, X-Frame-Options, etc.) worden niet vermeld in de brontekst.*
+  - *Security headers worden niet genoemd in de brontekst.*
 - **NOT_FOUND** (high) — [https://internet.nl/about/](https://internet.nl/about/)
-  - *Security headers (CSP, X-Frame-Options, etc.) worden niet vermeld in de brontekst.*
+  - *De brontekst gaat over wat internet.nl is en wie erachter zit. Specifieke testitems of Forum Standaardisatie-statussen worden niet vermeld.*
 
 ### `inet-0009` — SKILL.md:58 *(§ Webstandaarden)*
 
-> RPKI (Route Origin Validation) heeft de Forum Standaardisatie-status 'Verplicht (pas-toe-of-leg-uit)' en beschermt BGP-routing.
+> RPKI heeft de Forum Standaardisatie-status 'Verplicht (pas-toe-of-leg-uit)' en beschermt BGP-routing via Route Origin Validation.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** RPKI / Forum Standaardisatie webstandaarden
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Webstandaarden / Forum Standaardisatie
 
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
-  - *RPKI wordt niet vermeld in de brontekst.*
+  - *RPKI wordt niet genoemd in de brontekst.*
 - **NOT_FOUND** (high) — [https://internet.nl/about/](https://internet.nl/about/)
-  - *RPKI wordt niet vermeld in de brontekst.*
+  - *De brontekst gaat over wat internet.nl is en wie erachter zit. Forum Standaardisatie-statussen worden niet vermeld.*
 
 ### `inet-0010` — SKILL.md:64 *(§ Mailstandaarden)*
 
 > SPF heeft de Forum Standaardisatie-status 'Verplicht (pas-toe-of-leg-uit)' en autoriseert verzendende mailservers.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** SPF / Forum Standaardisatie mailstandaarden
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Mailstandaarden / Forum Standaardisatie
 
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
-  - *SPF wordt niet vermeld in de brontekst.*
+  - *SPF wordt niet genoemd in de brontekst.*
 - **NOT_FOUND** (high) — [https://internet.nl/about/](https://internet.nl/about/)
-  - *SPF wordt niet vermeld in de brontekst. De bron noemt SMTP alleen als voorbeeld van een bekende e-mailprotocol, zonder Forum Standaardisatie-statusinformatie.*
+  - *De brontekst gaat over wat internet.nl is en wie erachter zit. Forum Standaardisatie-statussen worden niet vermeld.*
 
 ### `inet-0011` — SKILL.md:65 *(§ Mailstandaarden)*
 
-> DKIM heeft de Forum Standaardisatie-status 'Verplicht (pas-toe-of-leg-uit)' en plaatst een digitale handtekening op e-mail.
+> DKIM heeft de Forum Standaardisatie-status 'Verplicht (pas-toe-of-leg-uit)' en biedt een digitale handtekening op e-mail.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DKIM / Forum Standaardisatie mailstandaarden
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Mailstandaarden / Forum Standaardisatie
 
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
-  - *DKIM wordt niet vermeld in de brontekst.*
+  - *DKIM wordt niet genoemd in de brontekst.*
 - **NOT_FOUND** (high) — [https://internet.nl/about/](https://internet.nl/about/)
-  - *DKIM wordt niet vermeld in de brontekst.*
+  - *De brontekst gaat over wat internet.nl is en wie erachter zit. Forum Standaardisatie-statussen worden niet vermeld.*
 
 ### `inet-0012` — SKILL.md:66 *(§ Mailstandaarden)*
 
 > DMARC heeft de Forum Standaardisatie-status 'Verplicht (pas-toe-of-leg-uit)' en bouwt voort op SPF en DKIM.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** DMARC / Forum Standaardisatie mailstandaarden
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Mailstandaarden / Forum Standaardisatie
 
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
-  - *DMARC wordt niet vermeld in de brontekst.*
+  - *DMARC wordt niet genoemd in de brontekst.*
 - **NOT_FOUND** (high) — [https://internet.nl/about/](https://internet.nl/about/)
-  - *DMARC wordt niet vermeld in de brontekst.*
+  - *De brontekst gaat over wat internet.nl is en wie erachter zit. Forum Standaardisatie-statussen worden niet vermeld.*
 
 ### `inet-0013` — SKILL.md:67 *(§ Mailstandaarden)*
 
-> STARTTLS + DANE heeft de Forum Standaardisatie-status 'Verplicht (pas-toe-of-leg-uit)'; STARTTLS versleutelt SMTP-verkeer en DANE biedt DNS-gebaseerde certificaatverificatie.
+> STARTTLS + DANE heeft de Forum Standaardisatie-status 'Verplicht (pas-toe-of-leg-uit)'; STARTTLS versleutelt SMTP-verkeer, DANE biedt DNS-gebaseerde certificaatverificatie.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** STARTTLS + DANE / Forum Standaardisatie mailstandaarden
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Mailstandaarden / Forum Standaardisatie
 
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
-  - *STARTTLS en DANE worden niet vermeld in de brontekst.*
+  - *STARTTLS en DANE worden niet genoemd in de brontekst.*
 - **NOT_FOUND** (high) — [https://internet.nl/about/](https://internet.nl/about/)
-  - *STARTTLS en DANE worden niet vermeld in de brontekst.*
+  - *De brontekst gaat over wat internet.nl is en wie erachter zit. Forum Standaardisatie-statussen worden niet vermeld.*
 
 ### `inet-0014` — SKILL.md:68 *(§ Mailstandaarden)*
 
-> IPv6 heeft de Forum Standaardisatie-status 'Verplicht (pas-toe-of-leg-uit)' voor de bereikbaarheid van MX- en nameservers.
+> IPv6 heeft de Forum Standaardisatie-status 'Verplicht (pas-toe-of-leg-uit)' voor mailstandaarden (bereikbaarheid van MX- en nameservers).
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** IPv6 / Forum Standaardisatie mailstandaarden
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Mailstandaarden / Forum Standaardisatie
 
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
-  - *IPv6 voor MX- en nameservers wordt niet vermeld in de brontekst.*
+  - *IPv6 voor mailstandaarden wordt niet genoemd in de brontekst.*
 - **NOT_FOUND** (high) — [https://internet.nl/about/](https://internet.nl/about/)
-  - *IPv6 voor MX- en nameservers wordt niet vermeld in de brontekst.*
+  - *De brontekst gaat over wat internet.nl is en wie erachter zit. Forum Standaardisatie-statussen worden niet vermeld.*
 
 ### `inet-0015` — SKILL.md:69 *(§ Mailstandaarden)*
 
-> RPKI heeft de Forum Standaardisatie-status 'Verplicht (pas-toe-of-leg-uit)' voor MX- en nameservers.
+> RPKI heeft de Forum Standaardisatie-status 'Verplicht (pas-toe-of-leg-uit)' voor mailstandaarden (Route Origin Validation voor MX- en nameservers).
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** RPKI / Forum Standaardisatie mailstandaarden
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Mailstandaarden / Forum Standaardisatie
 
 - **NOT_FOUND** (high) — [https://www.forumstandaardisatie.nl/open-standaarden](https://www.forumstandaardisatie.nl/open-standaarden)
-  - *RPKI voor MX- en nameservers wordt niet vermeld in de brontekst.*
+  - *RPKI voor mailstandaarden wordt niet genoemd in de brontekst.*
 - **NOT_FOUND** (high) — [https://internet.nl/about/](https://internet.nl/about/)
-  - *RPKI voor MX- en nameservers wordt niet vermeld in de brontekst.*
+  - *De brontekst gaat over wat internet.nl is en wie erachter zit. Forum Standaardisatie-statussen worden niet vermeld.*
 
-## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (1)
+## PARTIALLY_GROUNDED — bron ondersteunt deel van de claim (3)
 
 ### `inet-0008` — SKILL.md:57 *(§ Webstandaarden)*
 
 > security.txt heeft de Forum Standaardisatie-status 'Verplicht (pas-toe-of-leg-uit)' en is gedefinieerd in RFC 9116.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** security.txt / Forum Standaardisatie webstandaarden
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Webstandaarden / Forum Standaardisatie
 
-- **PARTIALLY_SUPPORTED** (high) — [https://www.rfc-editor.org/rfc/rfc9116.txt](https://www.rfc-editor.org/rfc/rfc9116.txt)
-  > This document defines a machine-parsable format ("security.txt") to help organizations describe their vulnerability disclosure practices... RFC 9116
-  - *De bron bevestigt dat security.txt gedefinieerd is in RFC 9116. De claim over de Forum Standaardisatie-status 'Verplicht (pas-toe-of-leg-uit)' wordt niet vermeld in deze bron — dat is een Nederlandse overheids-classificatie die buiten de scope van de RFC valt.*
+- **PARTIALLY_SUPPORTED** (medium) — [https://www.rfc-editor.org/rfc/rfc9116.txt](https://www.rfc-editor.org/rfc/rfc9116.txt)
+  > This document defines a machine-parsable format ("security.txt") to help organizations describe their vulnerability disclosure practices... [published as] RFC 9116
+  - *De bron bevestigt dat security.txt gedefinieerd is in RFC 9116. Echter, de Forum Standaardisatie-status 'Verplicht (pas-toe-of-leg-uit)' wordt nergens in de RFC vermeld — dat is een Nederlandse overheidsclassificatie die buiten de scope van dit document valt.*
 
-## GROUNDED — minstens één bron ondersteunt de claim (5)
+### `inet-0017` — SKILL.md:79 *(§ Repositories)*
+
+> De documentatie voor de batch API (v2) van internet.nl staat in de repository Internet.nl-API-docs onder CC-BY-4.0 licentie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl repositories / Batch API v2
+
+- **SOURCE_UNAVAILABLE** (high) — [https://raw.githubusercontent.com/internetstandards/Internet.nl/main/LICENSE](https://raw.githubusercontent.com/internetstandards/Internet.nl/main/LICENSE)
+  - *Bron status: unreachable*
+- **SOURCE_UNAVAILABLE** (high) — [https://raw.githubusercontent.com/internetstandards/Internet.nl/master/LICENSE](https://raw.githubusercontent.com/internetstandards/Internet.nl/master/LICENSE)
+  - *Bron status: unreachable*
+- **PARTIALLY_SUPPORTED** (medium) — [https://github.com/internetstandards/Internet.nl-API-docs](https://github.com/internetstandards/Internet.nl-API-docs)
+  > Documentation on the Internet.nl batch API and web-based dashboard [...] LICENSE-CC-BY-4.0.txt
+  - *De bron bevestigt dat de repository Internet.nl-API-docs documentatie bevat over de batch API én een CC-BY-4.0 licentiebestand aanwezig is. De claim noemt specifiek 'v2', maar de bron toont mappen v1.1 en v2.0 zonder expliciet te stellen dat v2 de huidige/hoofdversie is. Het CC-BY-4.0 karakter is ondersteund via het aanwezige licentiebestand, maar niet expliciet als licentietekst vermeld.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+  - *De brontekst beschrijft de hoofdrepository internetstandards/Internet.nl. Er is geen vermelding van een aparte 'Internet.nl-API-docs' repository of batch API v2 documentatie.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  - *De brontekst beschrijft de toolbox-wiki repository. Er is geen vermelding van een 'Internet.nl-API-docs' repository of batch API v2 documentatie.*
+
+### `inet-0018` — SKILL.md:80 *(§ Repositories)*
+
+> De implementatiegidsen per standaard en platform staan in de toolbox-wiki repository onder CC-BY-4.0 licentie.
+
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl repositories
+
+- **PARTIALLY_SUPPORTED** (medium) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
+  > This GitHub repository contains several how-to's for providing practical information and guidance on implementing secure and modern Internet Standards. [...] LICENSE-CC-BY-4.0.txt
+  - *De bron bevestigt dat de toolbox-wiki implementatiegidsen bevat en dat er een CC-BY-4.0 licentiebestand aanwezig is. De claim dat het 'per standaard en platform' is wordt deels ondersteund (DANE, DKIM, SPF, DMARC how-to's zijn zichtbaar), maar 'per platform' wordt niet expliciet vermeld. De CC-BY-4.0 licentie is aanwezig als bestand maar wordt niet expliciet als de geldende licentie benoemd in de tekst.*
+- **SOURCE_UNAVAILABLE** (high) — [https://raw.githubusercontent.com/internetstandards/toolbox-wiki/main/LICENSE](https://raw.githubusercontent.com/internetstandards/toolbox-wiki/main/LICENSE)
+  - *Bron status: unreachable*
+- **SOURCE_UNAVAILABLE** (high) — [https://raw.githubusercontent.com/internetstandards/toolbox-wiki/master/LICENSE](https://raw.githubusercontent.com/internetstandards/toolbox-wiki/master/LICENSE)
+  - *Bron status: unreachable*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
+  - *De brontekst maakt geen melding van een 'toolbox-wiki' repository of implementatiegidsen per standaard en platform.*
+- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl-API-docs](https://github.com/internetstandards/Internet.nl-API-docs)
+  - *De brontekst gaat uitsluitend over Internet.nl-API-docs. Er is geen vermelding van een toolbox-wiki repository of implementatiegidsen per standaard en platform.*
+
+## GROUNDED — minstens één bron ondersteunt de claim (2)
 
 <details>
 <summary>Klap uit voor alle GROUNDED claims</summary>
 
 ### `inet-0016` — SKILL.md:78 *(§ Repositories)*
 
-> De internet.nl testsuite (Internet.nl repository) is gepubliceerd onder Apache-2.0 licentie voor code en CC-BY-4.0 voor vertalingen.
+> De internet.nl testsuite (Python/Django) is gepubliceerd onder Apache-2.0 (code) en CC-BY-4.0 (vertalingen) op GitHub.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl repository licenties
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl repositories
 
+- **SOURCE_UNAVAILABLE** (high) — [https://raw.githubusercontent.com/internetstandards/Internet.nl/main/LICENSE](https://raw.githubusercontent.com/internetstandards/Internet.nl/main/LICENSE)
+  - *Bron status: unreachable*
+- **SOURCE_UNAVAILABLE** (high) — [https://raw.githubusercontent.com/internetstandards/Internet.nl/master/LICENSE](https://raw.githubusercontent.com/internetstandards/Internet.nl/master/LICENSE)
+  - *Bron status: unreachable*
 - **SUPPORTED** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
   > This project is licensed under the Apache License, Version 2.0 - see the LICENSE-Apache-2.0.txt file for details. The files under the /translations folder are licensed under Attribution 4.0 International (CC BY 4.0) - see the LICENSE-CC-BY-4.0.txt file for details.
 - **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl-API-docs](https://github.com/internetstandards/Internet.nl-API-docs)
-  - *De brontekst is de GitHub-pagina van de Internet.nl-API-docs repository en bevat geen informatie over de licentie van de internet.nl testsuite (het hoofdrepository). Er wordt alleen een LICENSE-CC-BY-4.0.txt bestand genoemd voor deze docs-repo zelf.*
+  - *De brontekst beschrijft alleen de Internet.nl-API-docs repository en vermeldt niets over de Python/Django testsuite of Apache-2.0 licentie.*
 - **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *De bron vermeldt alleen CC-BY-4.0 (zichtbaar in het bestandsoverzicht: LICENSE-CC-BY-4.0.txt), maar gaat over de toolbox-wiki, niet over de internet.nl testsuite. Apache-2.0 en vertalingen worden niet genoemd.*
+  - *De brontekst gaat over de toolbox-wiki repository, niet over de internet.nl testsuite (Python/Django). Geen informatie over Apache-2.0 of code/vertalingen licenties van de testsuite.*
 
-### `inet-0017` — SKILL.md:79 *(§ Repositories)*
-
-> De Internet.nl-API-docs repository (documentatie voor de batch API v2) is gepubliceerd onder de CC-BY-4.0 licentie.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl Batch API v2 documentatie
-
-- **SUPPORTED** (medium) — [https://github.com/internetstandards/Internet.nl-API-docs](https://github.com/internetstandards/Internet.nl-API-docs)
-  > LICENSE-CC-BY-4.0.txt
-  - *De brontekst toont een bestand genaamd 'LICENSE-CC-BY-4.0.txt' in de Internet.nl-API-docs repository. Dit is een sterke indicatie dat de CC-BY-4.0 licentie van toepassing is, hoewel de volledige licentietekst niet in de verstrekte bron staat.*
-- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
-  - *De bron beschrijft alleen de Internet.nl repository zelf, niet een aparte API-docs repository. Geen informatie over de licentie van die repository.*
-- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *De bron behandelt de toolbox-wiki repository, niet de Internet.nl-API-docs repository. De CC-BY-4.0 licentie voor die specifieke repo wordt hier niet bevestigd.*
-
-### `inet-0018` — SKILL.md:80 *(§ Repositories)*
-
-> De toolbox-wiki repository (implementatiegidsen per standaard en platform) is gepubliceerd onder de CC-BY-4.0 licentie.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl toolbox-wiki licentie
-
-- **SUPPORTED** (medium) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  > LICENSE-CC-BY-4.0.txt (bestandsnaam zichtbaar in repository bestandsoverzicht van internetstandards/toolbox-wiki)
-  - *De aanwezigheid van LICENSE-CC-BY-4.0.txt in de repository impliceert sterk de CC-BY-4.0 licentie, maar de licentie wordt nergens expliciet als tekst vermeld in de aangeleverde brontekst. Confidence medium omdat het een bestandsnaam is, geen uitgeschreven licentievermelding.*
-- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
-  - *De bron beschrijft alleen de Internet.nl repository zelf, niet een aparte toolbox-wiki repository. Geen informatie over de licentie van die repository.*
-- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl-API-docs](https://github.com/internetstandards/Internet.nl-API-docs)
-  - *De brontekst behandelt uitsluitend de Internet.nl-API-docs repository. Er is geen informatie over een toolbox-wiki repository of de licentie daarvan.*
-
-### `inet-0019` — SKILL.md:78 *(§ Repositories)*
-
-> De internet.nl testsuite is gebouwd met Python/Django.
-
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl technische implementatie
-
-- **SUPPORTED** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
-  > Python 3 (main programming language) Django (web framework)
-- **NOT_FOUND** (high) — [https://github.com/internetstandards/Internet.nl-API-docs](https://github.com/internetstandards/Internet.nl-API-docs)
-  - *De brontekst bevat geen informatie over de technische implementatie (Python/Django) van de internet.nl testsuite.*
-- **NOT_FOUND** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
-  - *De bron gaat over de toolbox-wiki (implementatiegidsen voor mailstandaarden), niet over de technische implementatie van de testsuite. Python/Django wordt niet vermeld.*
-
-### `inet-0020` — SKILL.md:73 *(§ Repositories)*
+### `inet-0019` — SKILL.md:73 *(§ Repositories)*
 
 > De broncode en documentatie van internet.nl staan onder de GitHub-organisatie 'internetstandards'.
 
-**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** Internet.nl GitHub organisatie
+**Type:** factual_assertion  ·  **Modaliteit:** STATEMENT  ·  **Scope:** internet.nl repositories
 
 - **SUPPORTED** (high) — [https://github.com/internetstandards/Internet.nl](https://github.com/internetstandards/Internet.nl)
   > internetstandards / Internet.nl Public
-  - *De repository URL en header tonen duidelijk dat de code staat onder de GitHub-organisatie 'internetstandards'.*
+  - *De repository staat expliciet onder de GitHub-organisatie 'internetstandards', zichtbaar in de repository-header 'internetstandards/Internet.nl'.*
 - **SUPPORTED** (high) — [https://github.com/internetstandards/Internet.nl-API-docs](https://github.com/internetstandards/Internet.nl-API-docs)
   > internetstandards / Internet.nl-API-docs Public
-  - *De brontekst toont duidelijk dat de repository onder de GitHub-organisatie 'internetstandards' staat: 'internetstandards / Internet.nl-API-docs'.*
+  - *De repository staat expliciet onder de GitHub-organisatie 'internetstandards', wat de claim bevestigt dat broncode en documentatie onder die organisatie staan.*
 - **SUPPORTED** (high) — [https://github.com/internetstandards/toolbox-wiki](https://github.com/internetstandards/toolbox-wiki)
   > internetstandards / toolbox-wiki Public
-  - *De repository staat expliciet onder de GitHub-organisatie 'internetstandards', zoals zichtbaar in de repository-naam en navigatie.*
+  - *De repository staat zichtbaar onder de GitHub-organisatie 'internetstandards', wat de claim bevestigt.*
 
 </details>


### PR DESCRIPTION
## Beschrijving

Voegt per skill een gegenereerde `audit.md` toe. De audit-pipeline detecteerde de verzonnen PDOK-API-key (skills-geo #232/#234) al, maar de bevinding stond alleen in een gitignore'd JSON die niemand opent. Committen maakt het zichtbaar in PR-review.

`UNSUPPORTED_ASSERTION` = stellige bewering zonder enige bronsteun. Hoog volume, bewust een triage-oppervlak — veel is waar-maar-onbronbaar; de checkbare specifieke claims zijn de interessante.

Workflow zit in aparte PR #177.

## Checklist

- [x] Geen hardcoded paden of persoonlijke gegevens
## Status: post-fix, niet meer stale

inet-mail/audit.md is opnieuw gegenereerd ná het mergen van #179 (DKIM-fix) en met de cache-TTL-fix actief. Resultaat: **0 CONTRADICTED** — de DKIM-2048-claim contradiceert niet langer omdat de skill nu correct toeschrijft (RFC 6376 = 1024-bit eis; 2048 = operationele aanbeveling). Het rapport geeft nu de werkelijke post-fix staat weer.

Branch is gerebased op huidige main (#177 + #179 zitten erin).