### PR TITLE
fix(inet-mail): DKIM-sleutellengte correct toegeschreven

### DIFF
--- a/skills/inet-mail/SKILL.md
+++ b/skills/inet-mail/SKILL.md
@@ -104,7 +104,8 @@ via een DNS-publicsleutel. De ontvangende mailserver verifieert de handtekening.
 - Publieke sleutel beschikbaar via DNS
 
 > **Let op:** Internet.nl controleert alleen of een DKIM-record bestaat; de sleutellengte
-> wordt niet getest. Best practice is minimaal 2048-bit RSA.
+> wordt niet getest. RFC 6376 vereist minimaal 1024-bit RSA voor langlevende sleutels;
+> 2048-bit is de huidige operationele aanbeveling (o.a. NIST, M3AAWG), niet een eis uit de RFC.
 
 **DNS-record formaat:**
 


### PR DESCRIPTION
## Wat

`skills/inet-mail/SKILL.md` zei: "Best practice is minimaal 2048-bit RSA" — geformuleerd alsof dat de norm/eis is, in een Let-op-blok direct na een verwijzing naar wat internet.nl test.

Herschreven naar: RFC 6376 vereist minimaal 1024-bit; 2048-bit is de huidige operationele aanbeveling (NIST, M3AAWG), niet een eis uit de RFC.

## Waarom

RFC 6376 (DKIM) zegt letterlijk:
> Signers MUST use RSA keys of at least 1024 bits for long-lived keys.

en duidt 2048-bit **nergens** aan als best practice of eis. De oude formulering schreef een 2048-bit-minimum impliciet aan de standaard toe die dat niet stelt. 2048-bit is wél terecht als operationele aanbeveling — dus dit is een herformulering (correct toeschrijven), geen verwijdering van het advies.

Bron: https://www.rfc-editor.org/rfc/rfc6376.txt — **live geverifieerd**.

## Hoe gevonden

Audit-sweep, `claim_status: CONTRADICTED` (RFC 6376 sprak het 2048-minimum tegen). Live bevestigd tegen de RFC.

## Checklist

- [x] Live geverifieerd tegen de RFC
- [x] Aanbeveling behouden, alleen correct toegeschreven
- [x] Geen hardcoded paden of persoonlijke gegevens